### PR TITLE
fix: provide database connection options to fx container for circuit breaker

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -109,5 +109,8 @@ func prepareDatabaseOptions(cmd *cobra.Command) (fx.Option, error) {
 		return nil, err
 	}
 
-	return storage.Module(*connectionOptions, service.IsDebug(cmd)), nil
+	return fx.Options(
+		fx.Supply(connectionOptions),
+		storage.Module(*connectionOptions, service.IsDebug(cmd)),
+	), nil
 }


### PR DESCRIPTION
Add `fx.Supply(connectionOptions)` to provide DB connection options to the Fx container.

The Circuit Breaker storage module required `*bunconnect.ConnectionOptions` as an Fx dependency, but it was not being supplied, causing a dependency injection issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-78023681-aafd-43b6-9c79-55d8619f81de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78023681-aafd-43b6-9c79-55d8619f81de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

