### PR TITLE
fix(api): increase timeout for ledger GetBalancesAggregated call

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/formancehq/go-libs/aws/iam"
 
@@ -40,6 +41,7 @@ func stackClientModule(cmd *cobra.Command) fx.Option {
 			}
 			underlyingHTTPClient := &http.Client{
 				Transport: otlp.NewRoundTripper(http.DefaultTransport, service.IsDebug(cmd)),
+				Timeout:   24 * time.Hour,
 			}
 			return sdk.New(
 				sdk.WithClient(

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
 
@@ -67,7 +66,7 @@ func (s *sdkFormanceClient) V2GetInfo(ctx context.Context) (*operations.V2GetInf
 }
 
 func (s *sdkFormanceClient) V2GetBalancesAggregated(ctx context.Context, req operations.V2GetBalancesAggregatedRequest) (*operations.V2GetBalancesAggregatedResponse, error) {
-	return s.client.Ledger.V2.GetBalancesAggregated(ctx, req, operations.WithOperationTimeout(24*time.Hour))
+	return s.client.Ledger.V2.GetBalancesAggregated(ctx, req)
 }
 
 var _ SDKFormance = (*sdkFormanceClient)(nil)


### PR DESCRIPTION
## Summary
- Increase SDK timeout for `V2GetBalancesAggregated` call from default 60s to 24 hours
- Allows long-running balance aggregation queries to complete without timeout errors

## Test plan
- [ ] Verify build passes
- [ ] Test reconciliation with large balance aggregation queries
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/formancehq/reconciliation/pull/43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
