### PR TITLE
feat(policy): introduce latest-version policy model and archive transition

### DIFF
--- a/internal/api/backend/backend.go
+++ b/internal/api/backend/backend.go
@@ -17,7 +17,7 @@ type Service interface {
 	ListReconciliations(ctx context.Context, q storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error)
 
 	CreatePolicy(ctx context.Context, req *service.CreatePolicyRequest) (*models.Policy, error)
-	CreatePolicyVersion(ctx context.Context, id string, req *service.CreatePolicyVersionRequest) (*models.Policy, error)
+	UpdatePolicy(ctx context.Context, id string, req *service.UpdatePolicyRequest) (*models.Policy, error)
 	ArchivePolicy(ctx context.Context, id string) error
 	GetPolicy(ctx context.Context, id string) (*models.Policy, error)
 	ListPolicies(ctx context.Context, q storage.GetPoliciesQuery) (*bunpaginate.Cursor[models.Policy], error)

--- a/internal/api/backend/backend.go
+++ b/internal/api/backend/backend.go
@@ -17,7 +17,8 @@ type Service interface {
 	ListReconciliations(ctx context.Context, q storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error)
 
 	CreatePolicy(ctx context.Context, req *service.CreatePolicyRequest) (*models.Policy, error)
-	DeletePolicy(ctx context.Context, id string) error
+	CreatePolicyVersion(ctx context.Context, id string, req *service.CreatePolicyVersionRequest) (*models.Policy, error)
+	ArchivePolicy(ctx context.Context, id string) error
 	GetPolicy(ctx context.Context, id string) (*models.Policy, error)
 	ListPolicies(ctx context.Context, q storage.GetPoliciesQuery) (*bunpaginate.Cursor[models.Policy], error)
 }

--- a/internal/api/backend/backend_generated.go
+++ b/internal/api/backend/backend_generated.go
@@ -53,18 +53,33 @@ func (mr *MockServiceMockRecorder) CreatePolicy(ctx, req interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockService)(nil).CreatePolicy), ctx, req)
 }
 
-// DeletePolicy mocks base method.
-func (m *MockService) DeletePolicy(ctx context.Context, id string) error {
+// CreatePolicyVersion mocks base method.
+func (m *MockService) CreatePolicyVersion(ctx context.Context, id string, req *service.CreatePolicyVersionRequest) (*models.Policy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeletePolicy", ctx, id)
+	ret := m.ctrl.Call(m, "CreatePolicyVersion", ctx, id, req)
+	ret0, _ := ret[0].(*models.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreatePolicyVersion indicates an expected call of CreatePolicyVersion.
+func (mr *MockServiceMockRecorder) CreatePolicyVersion(ctx, id, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyVersion", reflect.TypeOf((*MockService)(nil).CreatePolicyVersion), ctx, id, req)
+}
+
+// ArchivePolicy mocks base method.
+func (m *MockService) ArchivePolicy(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ArchivePolicy", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeletePolicy indicates an expected call of DeletePolicy.
-func (mr *MockServiceMockRecorder) DeletePolicy(ctx, id interface{}) *gomock.Call {
+// ArchivePolicy indicates an expected call of ArchivePolicy.
+func (mr *MockServiceMockRecorder) ArchivePolicy(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicy", reflect.TypeOf((*MockService)(nil).DeletePolicy), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchivePolicy", reflect.TypeOf((*MockService)(nil).ArchivePolicy), ctx, id)
 }
 
 // GetPolicy mocks base method.

--- a/internal/api/backend/backend_generated.go
+++ b/internal/api/backend/backend_generated.go
@@ -53,19 +53,19 @@ func (mr *MockServiceMockRecorder) CreatePolicy(ctx, req interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockService)(nil).CreatePolicy), ctx, req)
 }
 
-// CreatePolicyVersion mocks base method.
-func (m *MockService) CreatePolicyVersion(ctx context.Context, id string, req *service.CreatePolicyVersionRequest) (*models.Policy, error) {
+// UpdatePolicy mocks base method.
+func (m *MockService) UpdatePolicy(ctx context.Context, id string, req *service.UpdatePolicyRequest) (*models.Policy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePolicyVersion", ctx, id, req)
+	ret := m.ctrl.Call(m, "UpdatePolicy", ctx, id, req)
 	ret0, _ := ret[0].(*models.Policy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreatePolicyVersion indicates an expected call of CreatePolicyVersion.
-func (mr *MockServiceMockRecorder) CreatePolicyVersion(ctx, id, req interface{}) *gomock.Call {
+// UpdatePolicy indicates an expected call of UpdatePolicy.
+func (mr *MockServiceMockRecorder) UpdatePolicy(ctx, id, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyVersion", reflect.TypeOf((*MockService)(nil).CreatePolicyVersion), ctx, id, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePolicy", reflect.TypeOf((*MockService)(nil).UpdatePolicy), ctx, id, req)
 }
 
 // ArchivePolicy mocks base method.

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -18,6 +18,8 @@ import (
 
 type policyResponse struct {
 	ID              string                 `json:"id"`
+	Version         int64                  `json:"version"`
+	Lifecycle       string                 `json:"lifecycle"`
 	Name            string                 `json:"name"`
 	CreatedAt       time.Time              `json:"createdAt"`
 	LedgerName      string                 `json:"ledgerName"`
@@ -42,7 +44,9 @@ func createPolicyHandler(b backend.Backend) http.HandlerFunc {
 		}
 
 		data := &policyResponse{
-			ID:              policy.ID.String(),
+			ID:              policy.PolicyID.String(),
+			Version:         policy.Version,
+			Lifecycle:       models.NormalizePolicyLifecycle(policy.Lifecycle).String(),
 			Name:            policy.Name,
 			CreatedAt:       policy.CreatedAt,
 			LedgerName:      policy.LedgerName,
@@ -56,11 +60,44 @@ func createPolicyHandler(b backend.Backend) http.HandlerFunc {
 	}
 }
 
-func deletePolicyHandler(b backend.Backend) http.HandlerFunc {
+func createPolicyVersionHandler(b backend.Backend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "policyID")
 
-		err := b.GetService().DeletePolicy(r.Context(), id)
+		var req service.CreatePolicyVersionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			api.BadRequest(w, ErrMissingOrInvalidBody, err)
+			return
+		}
+
+		policy, err := b.GetService().CreatePolicyVersion(r.Context(), id, &req)
+		if err != nil {
+			handleServiceErrors(w, r, err)
+			return
+		}
+
+		data := &policyResponse{
+			ID:              policy.PolicyID.String(),
+			Version:         policy.Version,
+			Lifecycle:       models.NormalizePolicyLifecycle(policy.Lifecycle).String(),
+			Name:            policy.Name,
+			CreatedAt:       policy.CreatedAt,
+			LedgerName:      policy.LedgerName,
+			LedgerQuery:     policy.LedgerQuery,
+			PaymentsPoolID:  policy.PaymentsPoolID.String(),
+			Mode:            models.NormalizeAssertionMode(policy.AssertionMode).String(),
+			AssertionConfig: policy.AssertionConfig,
+		}
+
+		api.Created(w, data)
+	}
+}
+
+func archivePolicyHandler(b backend.Backend) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "policyID")
+
+		err := b.GetService().ArchivePolicy(r.Context(), id)
 		if err != nil {
 			handleServiceErrors(w, r, err)
 			return
@@ -81,7 +118,9 @@ func getPolicyHandler(b backend.Backend) http.HandlerFunc {
 		}
 
 		data := &policyResponse{
-			ID:              policy.ID.String(),
+			ID:              policy.PolicyID.String(),
+			Version:         policy.Version,
+			Lifecycle:       models.NormalizePolicyLifecycle(policy.Lifecycle).String(),
 			Name:            policy.Name,
 			CreatedAt:       policy.CreatedAt,
 			LedgerName:      policy.LedgerName,
@@ -122,7 +161,9 @@ func listPoliciesHandler(b backend.Backend) http.HandlerFunc {
 
 		api.RenderCursor(w, *bunpaginate.MapCursor(cursor, func(policy models.Policy) policyResponse {
 			return policyResponse{
-				ID:              policy.ID.String(),
+				ID:              policy.PolicyID.String(),
+				Version:         policy.Version,
+				Lifecycle:       models.NormalizePolicyLifecycle(policy.Lifecycle).String(),
 				Name:            policy.Name,
 				CreatedAt:       policy.CreatedAt,
 				LedgerName:      policy.LedgerName,

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -60,17 +60,17 @@ func createPolicyHandler(b backend.Backend) http.HandlerFunc {
 	}
 }
 
-func createPolicyVersionHandler(b backend.Backend) http.HandlerFunc {
+func updatePolicyHandler(b backend.Backend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "policyID")
 
-		var req service.CreatePolicyVersionRequest
+		var req service.UpdatePolicyRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			api.BadRequest(w, ErrMissingOrInvalidBody, err)
 			return
 		}
 
-		policy, err := b.GetService().CreatePolicyVersion(r.Context(), id, &req)
+		policy, err := b.GetService().UpdatePolicy(r.Context(), id, &req)
 		if err != nil {
 			handleServiceErrors(w, r, err)
 			return
@@ -89,7 +89,7 @@ func createPolicyVersionHandler(b backend.Backend) http.HandlerFunc {
 			AssertionConfig: policy.AssertionConfig,
 		}
 
-		api.Created(w, data)
+		api.Ok(w, data)
 	}
 }
 

--- a/internal/api/policy_test.go
+++ b/internal/api/policy_test.go
@@ -192,6 +192,8 @@ func TestArchivePolicy(t *testing.T) {
 	type testCase struct {
 		name               string
 		policyID           string
+		method             string
+		path               string
 		expectedStatusCode int
 		serviceError       error
 		expectedErrorCode  string
@@ -201,10 +203,20 @@ func TestArchivePolicy(t *testing.T) {
 		{
 			name:     "nominal",
 			policyID: "00000000-0000-0000-0000-000000000000",
+			method:   http.MethodPost,
+			path:     "/archive",
+		},
+		{
+			name:     "nominal deprecated delete alias",
+			policyID: "00000000-0000-0000-0000-000000000000",
+			method:   http.MethodDelete,
+			path:     "",
 		},
 		{
 			name:               "service error validation",
 			policyID:           "00000000-0000-0000-0000-000000000000",
+			method:             http.MethodPost,
+			path:               "/archive",
 			serviceError:       service.ErrValidation,
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  ErrValidation,
@@ -212,6 +224,8 @@ func TestArchivePolicy(t *testing.T) {
 		{
 			name:               "service error invalid id",
 			policyID:           "invalid",
+			method:             http.MethodPost,
+			path:               "/archive",
 			serviceError:       service.ErrInvalidID,
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  ErrInvalidID,
@@ -219,6 +233,8 @@ func TestArchivePolicy(t *testing.T) {
 		{
 			name:               "storage error not found",
 			policyID:           "invalid",
+			method:             http.MethodPost,
+			path:               "/archive",
 			serviceError:       storage.ErrNotFound,
 			expectedStatusCode: http.StatusNotFound,
 			expectedErrorCode:  sharedapi.ErrorCodeNotFound,
@@ -226,6 +242,8 @@ func TestArchivePolicy(t *testing.T) {
 		{
 			name:               "service error other error",
 			policyID:           "00000000-0000-0000-0000-000000000000",
+			method:             http.MethodPost,
+			path:               "/archive",
 			serviceError:       errors.New("some error"),
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedErrorCode:  sharedapi.ErrorInternal,
@@ -239,6 +257,9 @@ func TestArchivePolicy(t *testing.T) {
 
 			if testCase.expectedStatusCode == 0 {
 				testCase.expectedStatusCode = http.StatusNoContent
+			}
+			if testCase.method == "" {
+				testCase.method = http.MethodPost
 			}
 
 			backend, mockService := newTestingBackend(t)
@@ -257,7 +278,7 @@ func TestArchivePolicy(t *testing.T) {
 				Debug: testing.Verbose(),
 			}, auth.NewNoAuth(), nil)
 
-			req := httptest.NewRequest(http.MethodPost, "/policies/"+testCase.policyID+"/archive", nil)
+			req := httptest.NewRequest(testCase.method, "/policies/"+testCase.policyID+testCase.path, nil)
 			rec := httptest.NewRecorder()
 
 			router.ServeHTTP(rec, req)

--- a/internal/api/policy_test.go
+++ b/internal/api/policy_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	sharedapi "github.com/formancehq/go-libs/api"
-	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/go-libs/auth"
+	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/reconciliation/internal/api/service"
 	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/storage"
@@ -116,6 +116,9 @@ func TestCreatePolicy(t *testing.T) {
 			if testCase.req != nil {
 				policyServiceResponse = models.Policy{
 					ID:              uuid.New(),
+					PolicyID:        uuid.New(),
+					Version:         1,
+					Lifecycle:       models.PolicyLifecycleEnabled,
 					CreatedAt:       time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					Name:            testCase.req.Name,
 					LedgerName:      testCase.req.LedgerName,
@@ -127,7 +130,9 @@ func TestCreatePolicy(t *testing.T) {
 			}
 
 			expectedPolicyResponse := &policyResponse{
-				ID:              policyServiceResponse.ID.String(),
+				ID:              policyServiceResponse.PolicyID.String(),
+				Version:         policyServiceResponse.Version,
+				Lifecycle:       policyServiceResponse.Lifecycle.String(),
 				Name:            policyServiceResponse.Name,
 				CreatedAt:       policyServiceResponse.CreatedAt,
 				LedgerName:      policyServiceResponse.LedgerName,
@@ -181,7 +186,7 @@ func TestCreatePolicy(t *testing.T) {
 	}
 }
 
-func TestDeletePolicy(t *testing.T) {
+func TestArchivePolicy(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -239,12 +244,12 @@ func TestDeletePolicy(t *testing.T) {
 			backend, mockService := newTestingBackend(t)
 			if testCase.expectedStatusCode < 300 && testCase.expectedStatusCode >= 200 {
 				mockService.EXPECT().
-					DeletePolicy(gomock.Any(), testCase.policyID).
+					ArchivePolicy(gomock.Any(), testCase.policyID).
 					Return(nil)
 			}
 			if testCase.serviceError != nil {
 				mockService.EXPECT().
-					DeletePolicy(gomock.Any(), testCase.policyID).
+					ArchivePolicy(gomock.Any(), testCase.policyID).
 					Return(testCase.serviceError)
 			}
 
@@ -252,7 +257,7 @@ func TestDeletePolicy(t *testing.T) {
 				Debug: testing.Verbose(),
 			}, auth.NewNoAuth(), nil)
 
-			req := httptest.NewRequest(http.MethodDelete, "/policies/"+testCase.policyID, nil)
+			req := httptest.NewRequest(http.MethodPost, "/policies/"+testCase.policyID+"/archive", nil)
 			rec := httptest.NewRecorder()
 
 			router.ServeHTTP(rec, req)
@@ -272,6 +277,9 @@ func TestListPolicies(t *testing.T) {
 
 	policy := models.Policy{
 		ID:              uuid.New(),
+		PolicyID:        uuid.New(),
+		Version:         1,
+		Lifecycle:       models.PolicyLifecycleEnabled,
 		Name:            "policy-1",
 		CreatedAt:       time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		LedgerName:      "ledger",
@@ -307,7 +315,9 @@ func TestListPolicies(t *testing.T) {
 	require.NotNil(t, resp.Cursor)
 	require.Len(t, resp.Cursor.Data, 1)
 	require.Equal(t, models.AssertionModeCoverage.String(), resp.Cursor.Data[0].Mode)
-	require.Equal(t, policy.ID.String(), resp.Cursor.Data[0].ID)
+	require.Equal(t, policy.PolicyID.String(), resp.Cursor.Data[0].ID)
+	require.Equal(t, policy.Version, resp.Cursor.Data[0].Version)
+	require.Equal(t, policy.Lifecycle.String(), resp.Cursor.Data[0].Lifecycle)
 }
 
 func TestGetPolicy(t *testing.T) {
@@ -369,6 +379,9 @@ func TestGetPolicy(t *testing.T) {
 			if testCase.policyID != "" {
 				policyServiceResponse = models.Policy{
 					ID:              uuid.MustParse(testCase.policyID),
+					PolicyID:        uuid.MustParse(testCase.policyID),
+					Version:         1,
+					Lifecycle:       models.PolicyLifecycleEnabled,
 					CreatedAt:       time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 					Name:            "test",
 					LedgerName:      "test",
@@ -380,7 +393,9 @@ func TestGetPolicy(t *testing.T) {
 			}
 
 			expectedPolicyResponse := &policyResponse{
-				ID:              policyServiceResponse.ID.String(),
+				ID:              policyServiceResponse.PolicyID.String(),
+				Version:         policyServiceResponse.Version,
+				Lifecycle:       policyServiceResponse.Lifecycle.String(),
 				Name:            policyServiceResponse.Name,
 				CreatedAt:       policyServiceResponse.CreatedAt,
 				LedgerName:      policyServiceResponse.LedgerName,

--- a/internal/api/reconciliation.go
+++ b/internal/api/reconciliation.go
@@ -20,6 +20,7 @@ import (
 type reconciliationResponse struct {
 	ID                   string              `json:"id"`
 	PolicyID             string              `json:"policyID"`
+	PolicyVersion        int64               `json:"policyVersion"`
 	CreatedAt            time.Time           `json:"createdAt"`
 	ReconciledAtLedger   time.Time           `json:"reconciledAtLedger"`
 	ReconciledAtPayments time.Time           `json:"reconciledAtPayments"`
@@ -58,7 +59,8 @@ func reconciliationHandler(b backend.Backend) http.HandlerFunc {
 
 		data := &reconciliationResponse{
 			ID:                   res.ID.String(),
-			PolicyID:             policyID,
+			PolicyID:             res.PolicyID.String(),
+			PolicyVersion:        res.PolicyVersion,
 			CreatedAt:            res.CreatedAt,
 			ReconciledAtLedger:   res.ReconciledAtLedger,
 			ReconciledAtPayments: res.ReconciledAtPayments,
@@ -86,6 +88,7 @@ func getReconciliationHandler(b backend.Backend) http.HandlerFunc {
 		data := &reconciliationResponse{
 			ID:                   res.ID.String(),
 			PolicyID:             res.PolicyID.String(),
+			PolicyVersion:        res.PolicyVersion,
 			CreatedAt:            res.CreatedAt,
 			ReconciledAtLedger:   res.ReconciledAtLedger,
 			ReconciledAtPayments: res.ReconciledAtPayments,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -38,6 +38,7 @@ func newRouter(
 		r.Post("/policies", createPolicyHandler(b))
 		r.Get("/policies", listPoliciesHandler(b))
 		r.Put("/policies/{policyID}", updatePolicyHandler(b))
+		r.Delete("/policies/{policyID}", archivePolicyHandler(b)) // Backward-compatible alias
 		r.Post("/policies/{policyID}/archive", archivePolicyHandler(b))
 		r.Get("/policies/{policyID}", getPolicyHandler(b))
 		r.Post("/policies/{policyID}/reconciliation", reconciliationHandler(b))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -37,7 +37,8 @@ func newRouter(
 
 		r.Post("/policies", createPolicyHandler(b))
 		r.Get("/policies", listPoliciesHandler(b))
-		r.Delete("/policies/{policyID}", deletePolicyHandler(b))
+		r.Post("/policies/{policyID}/versions", createPolicyVersionHandler(b))
+		r.Post("/policies/{policyID}/archive", archivePolicyHandler(b))
 		r.Get("/policies/{policyID}", getPolicyHandler(b))
 		r.Post("/policies/{policyID}/reconciliation", reconciliationHandler(b))
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -37,7 +37,7 @@ func newRouter(
 
 		r.Post("/policies", createPolicyHandler(b))
 		r.Get("/policies", listPoliciesHandler(b))
-		r.Post("/policies/{policyID}/versions", createPolicyVersionHandler(b))
+		r.Put("/policies/{policyID}", updatePolicyHandler(b))
 		r.Post("/policies/{policyID}/archive", archivePolicyHandler(b))
 		r.Get("/policies/{policyID}", getPolicyHandler(b))
 		r.Post("/policies/{policyID}/reconciliation", reconciliationHandler(b))

--- a/internal/api/service/policy.go
+++ b/internal/api/service/policy.go
@@ -24,6 +24,8 @@ type CreatePolicyRequest struct {
 	AssertionConfig map[string]interface{} `json:"assertionConfig"`
 }
 
+type CreatePolicyVersionRequest = CreatePolicyRequest
+
 func (r *CreatePolicyRequest) Validate() error {
 	if r.Name == "" {
 		return fmt.Errorf("%w: missing name", ErrValidation)
@@ -68,8 +70,11 @@ func (s *Service) CreatePolicy(ctx context.Context, req *CreatePolicyRequest) (*
 
 	policy := &models.Policy{
 		ID:              uuid.New(),
+		PolicyID:        uuid.New(),
+		Version:         1,
 		Name:            req.Name,
 		CreatedAt:       time.Now().UTC(),
+		Lifecycle:       models.PolicyLifecycleEnabled,
 		LedgerName:      req.LedgerName,
 		LedgerQuery:     req.LedgerQuery,
 		PaymentsPoolID:  paymentPoolID,
@@ -80,6 +85,46 @@ func (s *Service) CreatePolicy(ctx context.Context, req *CreatePolicyRequest) (*
 	err = s.store.CreatePolicy(ctx, policy)
 	if err != nil {
 		return nil, newStorageError(err, "creating policy")
+	}
+
+	return policy, nil
+}
+
+func (s *Service) CreatePolicyVersion(ctx context.Context, id string, req *CreatePolicyVersionRequest) (*models.Policy, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	policyID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, errors.Wrap(ErrInvalidID, err.Error())
+	}
+
+	latest, err := s.store.GetPolicy(ctx, policyID)
+	if err != nil {
+		return nil, newStorageError(err, "getting policy")
+	}
+
+	paymentPoolID, err := uuid.Parse(req.PaymentsPoolID)
+	if err != nil {
+		return nil, errors.Wrap(ErrInvalidID, err.Error())
+	}
+
+	policy := &models.Policy{
+		ID:              uuid.New(),
+		PolicyID:        latest.PolicyID,
+		Name:            req.Name,
+		CreatedAt:       time.Now().UTC(),
+		Lifecycle:       latest.Lifecycle,
+		LedgerName:      req.LedgerName,
+		LedgerQuery:     req.LedgerQuery,
+		PaymentsPoolID:  paymentPoolID,
+		AssertionMode:   req.AssertionMode,
+		AssertionConfig: req.AssertionConfig,
+	}
+
+	if err := s.store.CreatePolicyVersion(ctx, policy); err != nil {
+		return nil, newStorageError(err, "creating policy version")
 	}
 
 	return policy, nil
@@ -150,13 +195,13 @@ func validateMinBufferRule(asset string, rule minBufferAssetRule) error {
 	return nil
 }
 
-func (s *Service) DeletePolicy(ctx context.Context, id string) error {
+func (s *Service) ArchivePolicy(ctx context.Context, id string) error {
 	pID, err := uuid.Parse(id)
 	if err != nil {
 		return errors.Wrap(ErrInvalidID, err.Error())
 	}
 
-	return newStorageError(s.store.DeletePolicy(ctx, pID), "deleting policy")
+	return newStorageError(s.store.ArchivePolicy(ctx, pID), "archiving policy")
 }
 
 func (s *Service) GetPolicy(ctx context.Context, id string) (*models.Policy, error) {

--- a/internal/api/service/policy.go
+++ b/internal/api/service/policy.go
@@ -24,7 +24,7 @@ type CreatePolicyRequest struct {
 	AssertionConfig map[string]interface{} `json:"assertionConfig"`
 }
 
-type CreatePolicyVersionRequest = CreatePolicyRequest
+type UpdatePolicyRequest = CreatePolicyRequest
 
 func (r *CreatePolicyRequest) Validate() error {
 	if r.Name == "" {
@@ -90,7 +90,7 @@ func (s *Service) CreatePolicy(ctx context.Context, req *CreatePolicyRequest) (*
 	return policy, nil
 }
 
-func (s *Service) CreatePolicyVersion(ctx context.Context, id string, req *CreatePolicyVersionRequest) (*models.Policy, error) {
+func (s *Service) UpdatePolicy(ctx context.Context, id string, req *UpdatePolicyRequest) (*models.Policy, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}

--- a/internal/api/service/reconciliation.go
+++ b/internal/api/service/reconciliation.go
@@ -18,6 +18,7 @@ import (
 type ReconciliationRequest struct {
 	ReconciledAtLedger   time.Time `json:"reconciledAtLedger"`
 	ReconciledAtPayments time.Time `json:"reconciledAtPayments"`
+	PolicyVersion        *int64    `json:"policyVersion,omitempty"`
 }
 
 func (r *ReconciliationRequest) Validate() error {
@@ -47,9 +48,17 @@ func (s *Service) Reconciliation(ctx context.Context, policyID string, req *Reco
 	}
 
 	eg, ctxGroup := errgroup.WithContext(ctx)
-	policy, err := s.store.GetPolicy(ctx, id)
-	if err != nil {
-		return nil, newStorageError(err, "failed to get policy")
+	var policy *models.Policy
+	if req.PolicyVersion != nil {
+		policy, err = s.store.GetPolicyVersion(ctx, id, *req.PolicyVersion)
+		if err != nil {
+			return nil, newStorageError(err, "failed to get policy version")
+		}
+	} else {
+		policy, err = s.store.GetPolicy(ctx, id)
+		if err != nil {
+			return nil, newStorageError(err, "failed to get policy")
+		}
 	}
 
 	var paymentsBalances map[string]*big.Int
@@ -70,6 +79,10 @@ func (s *Service) Reconciliation(ctx context.Context, policyID string, req *Reco
 		return nil, err
 	}
 
+	if normalized := models.NormalizePolicyLifecycle(policy.Lifecycle); normalized != models.PolicyLifecycleEnabled {
+		return nil, fmt.Errorf("%w: policy is not enabled", ErrValidation)
+	}
+
 	assertionMode := models.NormalizeAssertionMode(policy.AssertionMode)
 	if !assertionMode.IsValid() {
 		return nil, fmt.Errorf("%w: invalid assertion mode on policy", ErrValidation)
@@ -85,7 +98,8 @@ func (s *Service) Reconciliation(ctx context.Context, policyID string, req *Reco
 
 	res := &models.Reconciliation{
 		ID:                   uuid.New(),
-		PolicyID:             policy.ID,
+		PolicyID:             policy.PolicyID,
+		PolicyVersion:        policy.Version,
 		CreatedAt:            time.Now().UTC(),
 		ReconciledAtLedger:   req.ReconciledAtLedger,
 		ReconciledAtPayments: req.ReconciledAtPayments,

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -15,8 +15,10 @@ import (
 type Store interface {
 	Ping() error
 	CreatePolicy(ctx context.Context, policy *models.Policy) error
-	DeletePolicy(ctx context.Context, id uuid.UUID) error
+	CreatePolicyVersion(ctx context.Context, policy *models.Policy) error
+	ArchivePolicy(ctx context.Context, id uuid.UUID) error
 	GetPolicy(ctx context.Context, id uuid.UUID) (*models.Policy, error)
+	GetPolicyVersion(ctx context.Context, policyID uuid.UUID, version int64) (*models.Policy, error)
 	ListPolicies(ctx context.Context, q storage.GetPoliciesQuery) (*bunpaginate.Cursor[models.Policy], error)
 
 	CreateReconciation(ctx context.Context, reco *models.Reconciliation) error

--- a/internal/api/service/service_test.go
+++ b/internal/api/service/service_test.go
@@ -94,7 +94,10 @@ type mockStore struct {
 func newMockStore(policy ...*models.Policy) *mockStore {
 	p := &models.Policy{
 		ID:              uuid.New(),
+		PolicyID:        uuid.New(),
+		Version:         1,
 		CreatedAt:       time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		Lifecycle:       models.PolicyLifecycleEnabled,
 		Name:            "test",
 		LedgerName:      "default",
 		LedgerQuery:     map[string]interface{}{},
@@ -119,13 +122,27 @@ func (s *mockStore) CreatePolicy(ctx context.Context, policy *models.Policy) err
 	return nil
 }
 
-func (s *mockStore) DeletePolicy(ctx context.Context, id uuid.UUID) error {
+func (s *mockStore) CreatePolicyVersion(ctx context.Context, policy *models.Policy) error {
+	if s.policy != nil {
+		policy.Version = s.policy.Version + 1
+	}
+	return nil
+}
+
+func (s *mockStore) ArchivePolicy(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
 func (s *mockStore) GetPolicy(ctx context.Context, id uuid.UUID) (*models.Policy, error) {
 	policy := *s.policy
-	policy.ID = id
+	policy.PolicyID = id
+	return &policy, nil
+}
+
+func (s *mockStore) GetPolicyVersion(ctx context.Context, policyID uuid.UUID, version int64) (*models.Policy, error) {
+	policy := *s.policy
+	policy.PolicyID = policyID
+	policy.Version = version
 	return &policy, nil
 }
 

--- a/internal/models/policy.go
+++ b/internal/models/policy.go
@@ -15,6 +15,18 @@ const (
 	AssertionModeMinBuffer AssertionMode = "MIN_BUFFER"
 )
 
+type PolicyLifecycle string
+
+const (
+	PolicyLifecycleEnabled  PolicyLifecycle = "ENABLED"
+	PolicyLifecycleDisabled PolicyLifecycle = "DISABLED"
+	PolicyLifecycleArchived PolicyLifecycle = "ARCHIVED"
+)
+
+func (l PolicyLifecycle) String() string {
+	return string(l)
+}
+
 func (a AssertionMode) String() string {
 	return string(a)
 }
@@ -35,13 +47,23 @@ func NormalizeAssertionMode(a AssertionMode) AssertionMode {
 	return a
 }
 
+func NormalizePolicyLifecycle(l PolicyLifecycle) PolicyLifecycle {
+	if l == "" {
+		return PolicyLifecycleEnabled
+	}
+	return l
+}
+
 type Policy struct {
 	bun.BaseModel `bun:"reconciliations.policy" json:"-"`
 
 	// Policy Related fields
-	ID        uuid.UUID `bun:",pk,nullzero" json:"id"`
-	CreatedAt time.Time `bun:",notnull" json:"createdAt"`
-	Name      string    `bun:",notnull" json:"name"`
+	ID        uuid.UUID       `bun:",pk,nullzero" json:"id"` // Version row id
+	PolicyID  uuid.UUID       `bun:",notnull" json:"policyID"`
+	Version   int64           `bun:",notnull" json:"version"`
+	CreatedAt time.Time       `bun:",notnull" json:"createdAt"`
+	Name      string          `bun:",notnull" json:"name"`
+	Lifecycle PolicyLifecycle `bun:",notnull,default:'ENABLED'" json:"lifecycle"`
 
 	// Reconciliation Needed fields
 	LedgerName      string                 `bun:",notnull" json:"ledgerName"`

--- a/internal/models/reconciliation.go
+++ b/internal/models/reconciliation.go
@@ -24,6 +24,7 @@ type Reconciliation struct {
 
 	ID                   uuid.UUID            `bun:",pk,nullzero" json:"id"`
 	PolicyID             uuid.UUID            `bun:",nullzero" json:"policyID"`
+	PolicyVersion        int64                `bun:",notnull,default:1" json:"policyVersion"`
 	CreatedAt            time.Time            `bun:",nullzero" json:"createdAt"`
 	ReconciledAtLedger   time.Time            `bun:",nullzero" json:"reconciledAtLedger"`
 	ReconciledAtPayments time.Time            `bun:",nullzero" json:"reconciledAtPayments"`

--- a/internal/storage/migrations/migrations.go
+++ b/internal/storage/migrations/migrations.go
@@ -81,5 +81,26 @@ func registerMigrations(migrator *migrations.Migrator) {
 				return err
 			},
 		},
+		migrations.Migration{
+			Up: func(tx bun.Tx) error {
+				_, err := tx.Exec(`
+					ALTER TABLE reconciliations.policy ADD COLUMN policy_id uuid;
+					UPDATE reconciliations.policy SET policy_id = id WHERE policy_id IS NULL;
+					ALTER TABLE reconciliations.policy ALTER COLUMN policy_id SET NOT NULL;
+
+					ALTER TABLE reconciliations.policy ADD COLUMN version bigint NOT NULL DEFAULT 1;
+					ALTER TABLE reconciliations.policy ADD COLUMN lifecycle text NOT NULL DEFAULT 'ENABLED';
+
+					CREATE UNIQUE INDEX IF NOT EXISTS reconciliations_policy_policy_id_version_ux
+					ON reconciliations.policy (policy_id, version);
+					CREATE INDEX IF NOT EXISTS reconciliations_policy_policy_id_version_idx
+					ON reconciliations.policy (policy_id, version DESC);
+
+					ALTER TABLE reconciliations.reconciliation DROP CONSTRAINT IF EXISTS reconciliation_policy_fk;
+					ALTER TABLE reconciliations.reconciliation ADD COLUMN policy_version bigint NOT NULL DEFAULT 1;
+				`)
+				return err
+			},
+		},
 	)
 }

--- a/internal/storage/policy.go
+++ b/internal/storage/policy.go
@@ -23,23 +23,13 @@ func (s *Storage) CreatePolicy(ctx context.Context, policy *models.Policy) error
 	return nil
 }
 
-func (s *Storage) DeletePolicy(ctx context.Context, id uuid.UUID) error {
-	_, err := s.db.NewDelete().
-		Model(&models.Policy{}).
-		Where("id = ?", id).
-		Exec(ctx)
-	if err != nil {
-		return e("failed to delete policy", err)
-	}
-
-	return nil
-}
-
 func (s *Storage) GetPolicy(ctx context.Context, id uuid.UUID) (*models.Policy, error) {
 	var policy models.Policy
 	err := s.db.NewSelect().
 		Model(&policy).
-		Where("id = ?", id).
+		Where("policy_id = ?", id).
+		Order("version DESC").
+		Limit(1).
 		Scan(ctx)
 	if err != nil {
 		return nil, e("failed to get policy", err)
@@ -48,8 +38,61 @@ func (s *Storage) GetPolicy(ctx context.Context, id uuid.UUID) (*models.Policy, 
 	return &policy, nil
 }
 
+func (s *Storage) GetPolicyVersion(ctx context.Context, policyID uuid.UUID, version int64) (*models.Policy, error) {
+	var policy models.Policy
+	err := s.db.NewSelect().
+		Model(&policy).
+		Where("policy_id = ?", policyID).
+		Where("version = ?", version).
+		Scan(ctx)
+	if err != nil {
+		return nil, e("failed to get policy", err)
+	}
+
+	return &policy, nil
+}
+
+func (s *Storage) CreatePolicyVersion(ctx context.Context, policy *models.Policy) error {
+	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		var latestVersion int64
+		if err := tx.NewSelect().
+			Model((*models.Policy)(nil)).
+			ColumnExpr("COALESCE(MAX(version), 0)").
+			Where("policy_id = ?", policy.PolicyID).
+			Scan(ctx, &latestVersion); err != nil {
+			return e("failed to get latest policy version", err)
+		}
+
+		policy.Version = latestVersion + 1
+		_, err := tx.NewInsert().Model(policy).Exec(ctx)
+		if err != nil {
+			return e("failed to create policy version", err)
+		}
+
+		return nil
+	})
+}
+
+func (s *Storage) ArchivePolicy(ctx context.Context, id uuid.UUID) error {
+	_, err := s.db.NewUpdate().
+		Model((*models.Policy)(nil)).
+		Set("lifecycle = ?", models.PolicyLifecycleArchived).
+		Where("policy_id = ?", id).
+		Exec(ctx)
+	if err != nil {
+		return e("failed to archive policy", err)
+	}
+	return nil
+}
+
 func (s *Storage) buildPolicyListQuery(selectQuery *bun.SelectQuery, q GetPoliciesQuery, where string, args []any) *bun.SelectQuery {
+	latestPolicyRows := s.db.NewSelect().
+		TableExpr("reconciliations.policy").
+		ColumnExpr("DISTINCT ON (policy_id) id").
+		OrderExpr("policy_id, version DESC")
+
 	selectQuery = selectQuery.
+		Where("id IN (?)", latestPolicyRows).
 		Order("created_at DESC")
 
 	if where != "" {
@@ -89,7 +132,9 @@ func (s *Storage) policyQueryContext(qb query.Builder, q GetPoliciesQuery) (stri
 			if operator != "$match" {
 				return "", nil, errors.Wrap(ErrInvalidQuery, "'id' and 'name' columns can only be used with $match")
 			}
-
+			if key == "id" {
+				return "policy_id = ?", []any{value}, nil
+			}
 			return fmt.Sprintf("%s = ?", key), []any{value}, nil
 		case "createdAt":
 			return fmt.Sprintf("created_at %s ?", query.DefaultComparisonOperatorsMapping[operator]), []any{value}, nil

--- a/internal/storage/policy_test.go
+++ b/internal/storage/policy_test.go
@@ -14,6 +14,9 @@ import (
 var (
 	p1 = &models.Policy{
 		ID:         uuid.New(),
+		PolicyID:   uuid.New(),
+		Version:    1,
+		Lifecycle:  models.PolicyLifecycleEnabled,
 		CreatedAt:  time.Now().Add(-1 * time.Hour),
 		Name:       "test1",
 		LedgerName: "default",
@@ -29,6 +32,9 @@ var (
 
 	p2 = &models.Policy{
 		ID:         uuid.New(),
+		PolicyID:   uuid.New(),
+		Version:    1,
+		Lifecycle:  models.PolicyLifecycleEnabled,
 		CreatedAt:  time.Now().Add(-2 * time.Hour),
 		Name:       "test2",
 		LedgerName: "default",
@@ -44,6 +50,9 @@ var (
 
 	p3 = &models.Policy{
 		ID:         uuid.New(),
+		PolicyID:   uuid.New(),
+		Version:    1,
+		Lifecycle:  models.PolicyLifecycleEnabled,
 		CreatedAt:  time.Now().Add(-3 * time.Hour),
 		Name:       "test3",
 		LedgerName: "default",
@@ -79,13 +88,13 @@ func TestPolicyList(t *testing.T) {
 	t.Run("with query id", func(t *testing.T) {
 		policies, err := store.ListPolicies(context.Background(), GetPoliciesQuery{
 			Options: PaginatedQueryOptions[PoliciesFilters]{
-				QueryBuilder: query.Match("id", p1.ID.String()),
+				QueryBuilder: query.Match("id", p1.PolicyID.String()),
 			},
 		})
 
 		require.NoError(t, err)
 		require.Len(t, policies.Data, 1)
-		require.Equal(t, policies.Data[0].ID, p1.ID)
+		require.Equal(t, policies.Data[0].PolicyID, p1.PolicyID)
 	})
 
 	t.Run("with query unknown id", func(t *testing.T) {
@@ -107,7 +116,7 @@ func TestPolicyList(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Len(t, policies.Data, 1)
-		require.Equal(t, policies.Data[0].ID, p1.ID)
+		require.Equal(t, policies.Data[0].PolicyID, p1.PolicyID)
 	})
 
 	t.Run("with query unknown name", func(t *testing.T) {

--- a/internal/storage/reconciliations_test.go
+++ b/internal/storage/reconciliations_test.go
@@ -15,7 +15,8 @@ import (
 var (
 	r1 = &models.Reconciliation{
 		ID:                   uuid.New(),
-		PolicyID:             p1.ID,
+		PolicyID:             p1.PolicyID,
+		PolicyVersion:        p1.Version,
 		CreatedAt:            time.Now().Add(-1 * time.Hour),
 		ReconciledAtLedger:   time.Now().Add(-1 * time.Hour),
 		ReconciledAtPayments: time.Now().Add(-1 * time.Hour),
@@ -37,7 +38,8 @@ var (
 
 	r2 = &models.Reconciliation{
 		ID:                   uuid.New(),
-		PolicyID:             p1.ID,
+		PolicyID:             p1.PolicyID,
+		PolicyVersion:        p1.Version,
 		CreatedAt:            time.Now().Add(-2 * time.Hour),
 		ReconciledAtLedger:   time.Now().Add(-2 * time.Hour),
 		ReconciledAtPayments: time.Now().Add(-2 * time.Hour),
@@ -50,7 +52,8 @@ var (
 
 	r3 = &models.Reconciliation{
 		ID:                   uuid.New(),
-		PolicyID:             p2.ID,
+		PolicyID:             p2.PolicyID,
+		PolicyVersion:        p2.Version,
 		CreatedAt:            time.Now().Add(-3 * time.Hour),
 		ReconciledAtLedger:   time.Now().Add(-3 * time.Hour),
 		ReconciledAtPayments: time.Now().Add(-3 * time.Hour),
@@ -128,7 +131,7 @@ func TestReconciliationList(t *testing.T) {
 	t.Run("with query policyID", func(t *testing.T) {
 		reconciliations, err := store.ListReconciliations(context.Background(), GetReconciliationsQuery{
 			Options: PaginatedQueryOptions[ReconciliationsFilters]{
-				QueryBuilder: query.Match("policyID", p1.ID.String()),
+				QueryBuilder: query.Match("policyID", p1.PolicyID.String()),
 			},
 		})
 		require.NoError(t, err)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,22 +56,6 @@ paths:
         - Authorization:
             - reconciliation:read
   /policies/{policyID}:
-    delete:
-      summary: Delete a policy
-      operationId: deletePolicy
-      tags:
-        - reconciliation.v1
-      description: Delete a policy by its id.
-      parameters:
-        - $ref: '#/components/parameters/PolicyID'
-      responses:
-        '204':
-          $ref: '#/components/responses/NoContent'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      security:
-        - Authorization:
-            - reconciliation:write
     get:
       summary: Get a policy
       tags:
@@ -87,6 +71,42 @@ paths:
       security:
         - Authorization:
             - reconciliation:read
+  /policies/{policyID}/versions:
+    post:
+      summary: Create a policy version
+      tags:
+        - reconciliation.v1
+      operationId: createPolicyVersion
+      description: Append a new immutable version to an existing policy.
+      parameters:
+        - $ref: '#/components/parameters/PolicyID'
+      requestBody:
+        $ref: '#/components/requestBodies/Policy'
+      responses:
+        '201':
+          $ref: '#/components/responses/Policy'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - Authorization:
+            - reconciliation:write
+  /policies/{policyID}/archive:
+    post:
+      summary: Archive a policy
+      operationId: archivePolicy
+      tags:
+        - reconciliation.v1
+      description: Archive a policy and prevent new reconciliations from using it.
+      parameters:
+        - $ref: '#/components/parameters/PolicyID'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - Authorization:
+            - reconciliation:write
   /policies/{policyID}/reconciliation:
     post:
       summary: Reconcile using a policy
@@ -366,6 +386,11 @@ components:
           type: string
           format: date-time
           example: '2021-01-01T00:00:00.000Z'
+        policyVersion:
+          type: integer
+          format: int64
+          example: 2
+          description: Optional explicit policy version to use. Defaults to latest.
     ReconciliationResponse:
       type: object
       required:
@@ -377,6 +402,8 @@ components:
       type: object
       required:
         - id
+        - version
+        - lifecycle
         - name
         - createdAt
         - ledgerName
@@ -388,6 +415,13 @@ components:
         id:
           type: string
           example: XXX
+          description: Stable policy identifier shared by all versions.
+        version:
+          type: integer
+          format: int64
+          example: 1
+        lifecycle:
+          $ref: '#/components/schemas/PolicyLifecycle'
         name:
           type: string
           example: XXX
@@ -416,11 +450,18 @@ components:
         - COVERAGE
         - EQUALITY
         - MIN_BUFFER
+    PolicyLifecycle:
+      type: string
+      enum:
+        - ENABLED
+        - DISABLED
+        - ARCHIVED
     Reconciliation:
       type: object
       required:
         - id
         - policyID
+        - policyVersion
         - createdAt
         - reconciledAtLedger
         - reconciledAtPayments
@@ -435,6 +476,10 @@ components:
         policyID:
           type: string
           example: XXX
+        policyVersion:
+          type: integer
+          format: int64
+          example: 3
         createdAt:
           type: string
           format: date-time

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,6 +56,25 @@ paths:
         - Authorization:
             - reconciliation:read
   /policies/{policyID}:
+    delete:
+      summary: Archive a policy (deprecated alias)
+      operationId: deletePolicy
+      deprecated: true
+      tags:
+        - reconciliation.v1
+      description: |
+        Deprecated backward-compatible alias for archiving a policy.
+        Use `POST /policies/{policyID}/archive` instead.
+      parameters:
+        - $ref: '#/components/parameters/PolicyID'
+      responses:
+        '204':
+          $ref: '#/components/responses/NoContent'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - Authorization:
+            - reconciliation:write
     put:
       summary: Update a policy
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,6 +56,24 @@ paths:
         - Authorization:
             - reconciliation:read
   /policies/{policyID}:
+    put:
+      summary: Update a policy
+      tags:
+        - reconciliation.v1
+      operationId: updatePolicy
+      description: Update a policy by appending a new immutable version.
+      parameters:
+        - $ref: '#/components/parameters/PolicyID'
+      requestBody:
+        $ref: '#/components/requestBodies/Policy'
+      responses:
+        '200':
+          $ref: '#/components/responses/Policy'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+      security:
+        - Authorization:
+            - reconciliation:write
     get:
       summary: Get a policy
       tags:
@@ -71,25 +89,6 @@ paths:
       security:
         - Authorization:
             - reconciliation:read
-  /policies/{policyID}/versions:
-    post:
-      summary: Create a policy version
-      tags:
-        - reconciliation.v1
-      operationId: createPolicyVersion
-      description: Append a new immutable version to an existing policy.
-      parameters:
-        - $ref: '#/components/parameters/PolicyID'
-      requestBody:
-        $ref: '#/components/requestBodies/Policy'
-      responses:
-        '201':
-          $ref: '#/components/responses/Policy'
-        default:
-          $ref: '#/components/responses/ErrorResponse'
-      security:
-        - Authorization:
-            - reconciliation:write
   /policies/{policyID}/archive:
     post:
       summary: Archive a policy


### PR DESCRIPTION
## Why
Regulated fintech teams need reconciliation runs to be reproducible and explainable over time.

Without version pinning, a policy update can make historical runs hard to interpret. This PR introduces a versioned policy model (without adding a new table) and lifecycle transitions so each reconciliation report can be tied to the exact policy version used.

This PR is intentionally chained on top of `feat/reconciliation-assertion-modes`.

## What changed
- Added one-table policy versioning fields on `reconciliations.policy`:
  - `policy_id` (stable logical policy id)
  - `version` (immutable snapshot number)
  - `lifecycle` (`ENABLED | DISABLED | ARCHIVED`)
- Added route-based transition:
  - `POST /policies/{policyID}/archive` to archive a policy family
- Policy updates now use:
  - `PUT /policies/{policyID}`
  - The API feels like an update, but implementation appends a new immutable version in background
- Reconciliation behavior:
  - defaults to latest policy version
  - supports optional explicit `policyVersion` override for replay/backfill
  - persists `policyVersion` in reconciliation reports
- OpenAPI updated to match new routes and schemas

## Backward compatibility
- `DELETE /policies/{policyID}` is kept as a deprecated alias and now performs archive semantics.
- Existing clients using `DELETE` continue to work while migrating to `POST /policies/{policyID}/archive`.

## Examples
Using `policyID = 7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e`.

### 1) Create + update policy (versioned in one table)
1. `POST /policies` -> creates `policyID=7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e`, `version=1`
2. `PUT /policies/7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e` -> creates `version=2` (new immutable row)
3. `GET /policies/7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e` -> returns latest (`version=2`)

### 2) Reconciliation defaults to latest
If this policy has versions `1` and `2`, then:
- `POST /policies/7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e/reconciliation` uses `version=2`
- reconciliation report stores:
  - `policyID: 7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e`
  - `policyVersion: 2`

### 3) Replay with explicit pinning
For historical replay:
- `POST /policies/7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e/reconciliation` with body:
```json
{
  "reconciledAtLedger": "2026-02-01T00:00:00Z",
  "reconciledAtPayments": "2026-02-01T00:00:00Z",
  "policyVersion": 1
}
```
Run is evaluated against version 1 and report stores `policyVersion: 1`.

### 4) Archive transition (no hard delete)
Preferred route:
- `POST /policies/7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e/archive`

Backward-compatible alias:
- `DELETE /policies/7b9f46d8-3aa5-4f2d-9af9-3f3dc1a94d4e`

In both cases:
- New reconciliations on this policy are rejected because lifecycle is not `ENABLED`.
- Historical reconciliations remain queryable.

## Data migration/backward compatibility
Migration backfills existing rows as:
- `policy_id = id`
- `version = 1`
- `lifecycle = ENABLED`

Also adds `policy_version` on reconciliation with default `1`.

## Validation
- `go test ./...`
