### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,45 +23,45 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768886240,
-        "narHash": "sha256-C2TjvwYZ2VDxYWeqvvJ5XPPp6U7H66zeJlRaErJKoEM=",
-        "rev": "80e4adbcf8992d3fd27ad4964fbb84907f9478b0",
-        "revCount": 930839,
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
+        "revCount": 909173,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.930839%2Brev-80e4adbcf8992d3fd27ad4964fbb84907f9478b0/019bdece-8709-77ea-a1d6-9d410df27131/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.909173%2Brev-44bae273f9f82d480273bab26f5c50de3724f52f/019cdb71-ee45-7469-aca0-9d5b9fedf5c5/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "revCount": 960399,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.960399%2Brev-9dcb002ca1690658be4a04645215baea8b95f31d/019cd400-6f38-7074-b8c8-f84603ddd88b/source.tar.gz"
       },
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1768886240,
-        "narHash": "sha256-C2TjvwYZ2VDxYWeqvvJ5XPPp6U7H66zeJlRaErJKoEM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "80e4adbcf8992d3fd27ad4964fbb84907f9478b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1769077615,
-        "narHash": "sha256-9IoUA8ag7I0E4fa9VHTxcPX1wYrS5VXZHx75PHsep0Q=",
+        "lastModified": 1773216331,
+        "narHash": "sha256-/H5YfZlOHqzOEfa/Tl8puHXDzx6gDjP+LsrJnsf+yKg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "18c1f3578a1ce9ed1bb7bf3f48cefbc0af0e34e4",
+        "rev": "0b75501907e4a99d18a95030409eb7fa152060c0",
         "type": "github"
       },
       "original": {
@@ -73,6 +73,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,39 +2,62 @@
   description = "Reconciliation service development environment";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
-    nur.url = "github:nix-community/NUR";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2511";
+    nixpkgs-unstable.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nur }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nur }:
     let
-      goVersion = 24;
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
-        pkgs = import nixpkgs {
-          inherit system;
-          config.allowUnfree = true;
-          overlays = [
-            nur.overlays.default
-            (final: prev: {
-              go = prev."go_1_${toString goVersion}";
-            })
-          ];
-        };
-      });
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forEachSupportedSystem = f:
+        nixpkgs.lib.genAttrs supportedSystems (system:
+          let
+            pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ nur.overlays.default ];
+              config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+                "goreleaser-pro"
+              ];
+            };
+            pkgs-unstable = import nixpkgs-unstable {
+              inherit system;
+            };
+          in
+          f { pkgs = pkgs; pkgs-unstable = pkgs-unstable; system = system; }
+        );
     in
     {
-      devShells = forEachSupportedSystem ({ pkgs }: {
-        default = pkgs.mkShell {
-          packages = [
-            pkgs.go
-            pkgs.gotools
-            pkgs.golangci-lint
-            pkgs.ginkgo
-            pkgs.nur.repos.goreleaser.goreleaser-pro
-            pkgs.just
+      devShells = forEachSupportedSystem ({ pkgs, pkgs-unstable, system }:
+        let
+          stablePackages = with pkgs; [
+            ginkgo
+            go_1_26
+            gotools
+            just
           ];
-        };
-      });
+          unstablePackages = with pkgs-unstable; [
+            golangci-lint
+          ];
+          otherPackages = [
+            pkgs.nur.repos.goreleaser.goreleaser-pro
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = stablePackages ++ unstablePackages ++ otherPackages;
+          };
+        }
+      );
     };
 }


### PR DESCRIPTION
## Summary
- Upgrade Go toolchain from 1.24 to 1.26 in nix dev shell
- Modernize flake.nix to use stable/unstable nixpkgs split
- Use `allowUnfreePredicate` instead of `allowUnfree = true`
- Update nix flake lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)