### PR TITLE
fix(db): drop UNIQUE constraint on reconciliation.created_at and index policy_id [EN-1202]

### DIFF
--- a/internal/storage/migrations/migrations.go
+++ b/internal/storage/migrations/migrations.go
@@ -72,5 +72,17 @@ func registerMigrations(migrator *migrations.Migrator) {
 				return err
 			},
 		},
+		migrations.Migration{
+			Up: func(tx bun.Tx) error {
+				// created_at is not a business invariant: two reconciliations
+				// triggered in the same microsecond must not fail on insert.
+				_, err := tx.Exec(`
+					ALTER TABLE reconciliations.reconciliation DROP CONSTRAINT IF EXISTS reconciliation_created_at_key;
+					CREATE INDEX IF NOT EXISTS reconciliation_created_at_idx ON reconciliations.reconciliation (created_at);
+					CREATE INDEX IF NOT EXISTS reconciliation_policy_id_idx ON reconciliations.reconciliation (policy_id);
+				`)
+				return err
+			},
+		},
 	)
 }


### PR DESCRIPTION
**Jira:** [EN-1202](https://formance-team.atlassian.net/browse/EN-1202) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

`internal/storage/migrations/migrations.go` creates `reconciliations.reconciliation.created_at` with an inline `UNIQUE` constraint. PostgreSQL timestamps have microsecond precision: two reconciliations created in the same microsecond (two concurrent `POST /policies/{id}/reconciliation`, even on different policies) violate the constraint and the second insert fails with a 500. `created_at` uniqueness is not a business invariant — `id` is already the primary key.

Additionally, the `policy_id` foreign key (with `ON DELETE CASCADE`) has no supporting index, so `policyID` filters and cascading deletes sequentially scan the table.

## Fix

New migration (idempotent, verified against PostgreSQL 16):
- `DROP CONSTRAINT IF EXISTS reconciliation_created_at_key` (default name verified)
- `CREATE INDEX` on `created_at` — keeps the `created_at DESC` list ordering fast (previously served by the unique index)
- `CREATE INDEX` on `policy_id`

## Tests

- `go test -tags it ./internal/storage/...` green (migrations run against dockerized PG)
- Constraint name and effective drop verified manually against postgres:16

Part of the repository review (REVIEW.md, finding H1 + L3).

[EN-1215]: https://formance-team.atlassian.net/browse/EN-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EN-1202]: https://formance-team.atlassian.net/browse/EN-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ