### PR TITLE
fix(api): enforce pageSize bounds, including cursor-decoded page sizes [EN-1206]

### DIFF
--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -98,6 +98,10 @@ func listPoliciesHandler(b backend.Backend) http.HandlerFunc {
 				api.BadRequest(w, ErrValidation, fmt.Errorf("invalid '%s' query param", QueryKeyCursor))
 				return
 			}
+			if err := validateCursorPageSize(q.PageSize); err != nil {
+				api.BadRequest(w, ErrValidation, fmt.Errorf("invalid '%s' query param: %w", QueryKeyCursor, err))
+				return
+			}
 		} else {
 			options, err := getPaginatedQueryOptionsPolicies(r)
 			if err != nil {

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -26,13 +26,10 @@ func getPageSize(r *http.Request) (uint64, error) {
 		return DefaultPageSize, nil
 	}
 
-	var pageSize uint64
-	var err error
-	if pageSizeParam != "" {
-		pageSize, err = strconv.ParseUint(pageSizeParam, 10, 32)
-		if err != nil {
-			return 0, ErrInvalidPageSize
-		}
+	pageSize, err := strconv.ParseUint(pageSizeParam, 10, 32)
+	if err != nil || pageSize == 0 {
+		// pageSize=0 would disable the SQL LIMIT entirely
+		return 0, ErrInvalidPageSize
 	}
 
 	if pageSize > MaxPageSize {
@@ -40,4 +37,14 @@ func getPageSize(r *http.Request) (uint64, error) {
 	}
 
 	return pageSize, nil
+}
+
+// validateCursorPageSize guards against forged cursors: a page size of 0
+// disables the SQL LIMIT and values above MaxPageSize bypass the cap
+// enforced by getPageSize.
+func validateCursorPageSize(pageSize uint64) error {
+	if pageSize == 0 || pageSize > MaxPageSize {
+		return ErrInvalidPageSize
+	}
+	return nil
 }

--- a/internal/api/query_test.go
+++ b/internal/api/query_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sharedapi "github.com/formancehq/go-libs/api"
+	"github.com/formancehq/go-libs/auth"
+	"github.com/formancehq/go-libs/bun/bunpaginate"
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+	"github.com/formancehq/reconciliation/internal/models"
+	"github.com/formancehq/reconciliation/internal/storage"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListReconciliationsPageSize(t *testing.T) {
+	t.Parallel()
+
+	forgedCursor := func(pageSize uint64) string {
+		q := storage.GetReconciliationsQuery{
+			PageSize: pageSize,
+			Options:  storage.NewPaginatedQueryOptions(storage.ReconciliationsFilters{}).WithPageSize(pageSize),
+		}
+		return bunpaginate.EncodeCursor(q)
+	}
+
+	type testCase struct {
+		name               string
+		queryParams        string
+		expectedStatusCode int
+		expectedPageSize   uint64
+	}
+
+	testCases := []testCase{
+		{
+			name:             "default page size",
+			queryParams:      "",
+			expectedPageSize: bunpaginate.QueryDefaultPageSize,
+		},
+		{
+			name:             "valid page size",
+			queryParams:      "?pageSize=10",
+			expectedPageSize: 10,
+		},
+		{
+			name:             "page size above max is capped",
+			queryParams:      "?pageSize=1000",
+			expectedPageSize: MaxPageSize,
+		},
+		{
+			name:               "page size zero is rejected",
+			queryParams:        "?pageSize=0",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "non numeric page size is rejected",
+			queryParams:        "?pageSize=abc",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:             "valid cursor",
+			queryParams:      "?cursor=" + forgedCursor(10),
+			expectedPageSize: 10,
+		},
+		{
+			name:               "forged cursor with page size zero is rejected",
+			queryParams:        "?cursor=" + forgedCursor(0),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "forged cursor with page size above max is rejected",
+			queryParams:        "?cursor=" + forgedCursor(1000000),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		testCase := tc
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.expectedStatusCode == 0 {
+				testCase.expectedStatusCode = http.StatusOK
+			}
+
+			backend, mockService := newTestingBackend(t)
+			if testCase.expectedStatusCode == http.StatusOK {
+				mockService.EXPECT().
+					ListReconciliations(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ any, q storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error) {
+						require.Equal(t, testCase.expectedPageSize, q.PageSize)
+						return &bunpaginate.Cursor[models.Reconciliation]{
+							PageSize: int(q.PageSize),
+							Data:     []models.Reconciliation{},
+						}, nil
+					})
+			}
+
+			router := newRouter(backend, sharedapi.ServiceInfo{
+				Debug: testing.Verbose(),
+			}, auth.NewNoAuth(), nil, publish.InMemory())
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/reconciliations%s", testCase.queryParams), nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, testCase.expectedStatusCode, rec.Code)
+		})
+	}
+}
+
+func TestListPoliciesPageSize(t *testing.T) {
+	t.Parallel()
+
+	forgedCursor := func(pageSize uint64) string {
+		q := storage.GetPoliciesQuery{
+			PageSize: pageSize,
+			Options:  storage.NewPaginatedQueryOptions(storage.PoliciesFilters{}).WithPageSize(pageSize),
+		}
+		return bunpaginate.EncodeCursor(q)
+	}
+
+	type testCase struct {
+		name               string
+		queryParams        string
+		expectedStatusCode int
+		expectedPageSize   uint64
+	}
+
+	testCases := []testCase{
+		{
+			name:               "page size zero is rejected",
+			queryParams:        "?pageSize=0",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "forged cursor with page size zero is rejected",
+			queryParams:        "?cursor=" + forgedCursor(0),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "forged cursor with page size above max is rejected",
+			queryParams:        "?cursor=" + forgedCursor(1000000),
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:             "valid cursor",
+			queryParams:      "?cursor=" + forgedCursor(10),
+			expectedPageSize: 10,
+		},
+	}
+
+	for _, tc := range testCases {
+		testCase := tc
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			if testCase.expectedStatusCode == 0 {
+				testCase.expectedStatusCode = http.StatusOK
+			}
+
+			backend, mockService := newTestingBackend(t)
+			if testCase.expectedStatusCode == http.StatusOK {
+				mockService.EXPECT().
+					ListPolicies(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ any, q storage.GetPoliciesQuery) (*bunpaginate.Cursor[models.Policy], error) {
+						require.Equal(t, testCase.expectedPageSize, q.PageSize)
+						return &bunpaginate.Cursor[models.Policy]{
+							PageSize: int(q.PageSize),
+							Data:     []models.Policy{},
+						}, nil
+					})
+			}
+
+			router := newRouter(backend, sharedapi.ServiceInfo{
+				Debug: testing.Verbose(),
+			}, auth.NewNoAuth(), nil, publish.InMemory())
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/policies%s", testCase.queryParams), nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, testCase.expectedStatusCode, rec.Code)
+		})
+	}
+}

--- a/internal/api/reconciliation.go
+++ b/internal/api/reconciliation.go
@@ -110,6 +110,10 @@ func listReconciliationsHandler(b backend.Backend) http.HandlerFunc {
 				api.BadRequest(w, ErrValidation, fmt.Errorf("invalid '%s' query param", QueryKeyCursor))
 				return
 			}
+			if err := validateCursorPageSize(q.PageSize); err != nil {
+				api.BadRequest(w, ErrValidation, fmt.Errorf("invalid '%s' query param: %w", QueryKeyCursor, err))
+				return
+			}
 		} else {
 			options, err := getPaginatedQueryOptionsReconciliations(r)
 			if err != nil {


### PR DESCRIPTION
**Jira:** [EN-1206](https://formance-team.atlassian.net/browse/EN-1206) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

Two paths allowed a client to run unbounded list queries:

1. `getPageSize()` capped values at `MaxPageSize` (100) but accepted `pageSize=0`. In go-libs `bunpaginate.usingOffset`, the SQL `LIMIT` is only applied when `PageSize > 0` — so `?pageSize=0` returned the **entire table** in one response.
2. In the list handlers, the `cursor` param is decoded with `bunpaginate.UnmarshalCursor` directly into the query struct, and the decoded `PageSize` was never re-validated. A forged cursor could set `pageSize: 0` or `pageSize: 10^9`, bypassing the cap entirely.

Authenticated DoS / data-dump vector on `GET /reconciliations` and `GET /policies`.

## Fix

- `pageSize=0` now returns a 400 (`VALIDATION`)
- page sizes decoded from cursors must be in `[1, MaxPageSize]`, otherwise 400
- removed a redundant condition in `getPageSize`

## Tests

New `query_test.go` covering: default page size, valid values, cap at 100, `pageSize=0`, non-numeric values, valid cursors, and forged cursors (0 and 10^6) on both list endpoints.

Part of the repository review (REVIEW.md, finding H2).

[EN-1206]: https://formance-team.atlassian.net/browse/EN-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ