### PR TITLE
fix(service): flag balance drift in both directions as NOT_OK [EN-1207]

### DIFF
--- a/internal/api/service/reconciliation.go
+++ b/internal/api/service/reconciliation.go
@@ -149,10 +149,10 @@ func (s *Service) computeDrift(
 		var drift big.Int
 		drift.Set(paymentBalance).Add(&drift, ledgerBalance)
 
+		// A discrepancy in either direction is a reconciliation failure:
+		// the ledger and the payments side must cancel each other out.
 		var err error
-		switch drift.Cmp(big.NewInt(0)) {
-		case 0, 1:
-		default:
+		if drift.Sign() != 0 {
 			err = fmt.Errorf("balance drift for asset %s", asset)
 		}
 

--- a/internal/api/service/reconciliation_fuzz_test.go
+++ b/internal/api/service/reconciliation_fuzz_test.go
@@ -63,14 +63,16 @@ func FuzzComputeDrift(f *testing.F) {
 			}
 		}
 
-		// Property: if both non-nil and equal in magnitude but opposite sign, drift should be 0
+		// Property: if both non-nil, an error is expected exactly when the
+		// sides do not cancel each other out (non-zero drift in either
+		// direction is a discrepancy).
 		if !ledgerNil && !paymentNil {
 			sum := new(big.Int).Add(big.NewInt(ledgerVal), big.NewInt(paymentVal))
-			if sum.Sign() >= 0 {
-				// No error expected
-				if err != nil {
-					t.Errorf("non-negative sum %s: expected no error, got %v", sum.String(), err)
-				}
+			if sum.Sign() == 0 && err != nil {
+				t.Errorf("zero sum: expected no error, got %v", err)
+			}
+			if sum.Sign() != 0 && err == nil {
+				t.Errorf("non-zero sum %s: expected an error, got nil", sum.String())
 			}
 		}
 	})

--- a/internal/api/service/reconciliation_test.go
+++ b/internal/api/service/reconciliation_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,7 +58,7 @@ func TestReconciliation(t *testing.T) {
 			},
 		},
 		{
-			name:            "nominal with drift >= 0",
+			name:            "nominal with drift > 0",
 			ledgerVersion:   "v2.0.0-beta.1",
 			paymentsVersion: "v1.0.0-rc.4",
 			ledgerBalances: map[string]*big.Int{
@@ -71,7 +72,7 @@ func TestReconciliation(t *testing.T) {
 			expectedReco: &models.Reconciliation{
 				ReconciledAtLedger:   time.Time{},
 				ReconciledAtPayments: time.Time{},
-				Status:               models.ReconciliationOK,
+				Status:               models.ReconciliationNotOK,
 				LedgerBalances: map[string]*big.Int{
 					"USD": big.NewInt(200),
 					"EUR": big.NewInt(300),
@@ -84,7 +85,7 @@ func TestReconciliation(t *testing.T) {
 					"USD": big.NewInt(100),
 					"EUR": big.NewInt(100),
 				},
-				Error: "",
+				Error: "balance drift for asset USD; balance drift for asset EUR",
 			},
 		},
 		{
@@ -179,7 +180,7 @@ func TestReconciliation(t *testing.T) {
 					"EUR": big.NewInt(200),
 					"DKK": big.NewInt(200),
 				},
-				Error: "balance drift for asset DKK",
+				Error: "balance drift for asset EUR; balance drift for asset DKK",
 			},
 		},
 		{
@@ -268,9 +269,18 @@ func TestReconciliation(t *testing.T) {
 			compareBalancesMap(t, tc.expectedReco.LedgerBalances, reco.LedgerBalances)
 			compareBalancesMap(t, tc.expectedReco.PaymentsBalances, reco.PaymentsBalances)
 			compareBalancesMap(t, tc.expectedReco.DriftBalances, reco.DriftBalances)
-			require.Equal(t, tc.expectedReco.Error, reco.Error)
+			// Per-asset errors are accumulated in map iteration order, which
+			// is not deterministic: compare them as a set.
+			require.ElementsMatch(t, splitErrors(tc.expectedReco.Error), splitErrors(reco.Error))
 		})
 	}
+}
+
+func splitErrors(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "; ")
 }
 
 func compareBalancesMap(t *testing.T, expected, actual map[string]*big.Int) {


### PR DESCRIPTION
**Jira:** [EN-1207](https://formance-team.atlassian.net/browse/EN-1207) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## ⚠️ Needs product/business confirmation before merge

The current behavior is asserted by an existing test (`nominal with drift >= 0` expected `OK`), so the asymmetry may have been intentional. Opening as **draft** so the intended semantics can be confirmed.

## Problem

`computeDrift` computes `drift = paymentsBalance + ledgerBalance` and only flags the reconciliation as `NOT_OK` when the drift is **negative**:

```go
switch drift.Cmp(big.NewInt(0)) {
case 0, 1:          // zero OR positive → no error
default:
    err = fmt.Errorf("balance drift for asset %s", asset)
}
```

With a positive drift the status stays `OK` and `error` is empty, even though the two sides do not cancel out — the drift is silently recorded in `driftBalances`. The README states the module should *"identify **any** discrepancies that need investigation"* and *"prove the assets in your ledger are backed by actual funds"* — a one-sided check does neither, and which side is 'safe' depends entirely on the sign convention of the policy's `ledgerQuery`.

## Fix

Any non-zero drift now sets `NOT_OK` + per-asset error. `driftBalances` content is unchanged (still absolute values).

## Tests

- Updated `nominal with drift > 0` (now expects `NOT_OK`) and the multi-asset case
- Per-asset error assertions made order-independent (errors accumulate in map iteration order)
- Fuzz property updated: error ⇔ non-zero sum; 10s fuzz run green

Part of the repository review (REVIEW.md, finding H3). Note: this function already had one production bug fixed in #62.

[EN-1207]: https://formance-team.atlassian.net/browse/EN-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ