### PR TITLE
fix(storage): reject unsupported operators on createdAt filters [EN-1208]

### DIFF
--- a/internal/storage/policy.go
+++ b/internal/storage/policy.go
@@ -92,7 +92,11 @@ func (s *Storage) policyQueryContext(qb query.Builder, q GetPoliciesQuery) (stri
 
 			return fmt.Sprintf("%s = ?", key), []any{value}, nil
 		case "createdAt":
-			return fmt.Sprintf("created_at %s ?", query.DefaultComparisonOperatorsMapping[operator]), []any{value}, nil
+			sqlOperator, ok := query.DefaultComparisonOperatorsMapping[operator]
+			if !ok {
+				return "", nil, errors.Wrapf(ErrInvalidQuery, "operator '%s' is not supported for 'createdAt'", operator)
+			}
+			return fmt.Sprintf("created_at %s ?", sqlOperator), []any{value}, nil
 		case "ledgerQuery":
 			if operator != "$match" {
 				return "", nil, errors.Wrap(ErrInvalidQuery, "'ledgerQuery' column can only be used with $match")

--- a/internal/storage/policy_test.go
+++ b/internal/storage/policy_test.go
@@ -127,4 +127,14 @@ func TestPolicyList(t *testing.T) {
 		require.Equal(t, policies.Data[0].ID, p2.ID)
 		require.Equal(t, policies.Data[1].ID, p3.ID)
 	})
+
+	t.Run("with unsupported operator on createdAt", func(t *testing.T) {
+		_, err := store.ListPolicies(context.Background(), GetPoliciesQuery{
+			Options: PaginatedQueryOptions[PoliciesFilters]{
+				QueryBuilder: query.Exists("createdAt", true),
+			},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidQuery)
+	})
 }

--- a/internal/storage/reconciliations.go
+++ b/internal/storage/reconciliations.go
@@ -88,7 +88,11 @@ func (s *Storage) reconciliationQueryContext(qb query.Builder, q GetReconciliati
 				return "", nil, errors.Wrap(ErrInvalidQuery, "'policyID' column can only be used with string")
 			}
 		case "createdAt":
-			return fmt.Sprintf("created_at %s ?", query.DefaultComparisonOperatorsMapping[operator]), []any{value}, nil
+			sqlOperator, ok := query.DefaultComparisonOperatorsMapping[operator]
+			if !ok {
+				return "", nil, errors.Wrapf(ErrInvalidQuery, "operator '%s' is not supported for 'createdAt'", operator)
+			}
+			return fmt.Sprintf("created_at %s ?", sqlOperator), []any{value}, nil
 		default:
 			return "", nil, errors.Wrapf(ErrInvalidQuery, "unknown key '%s' when building query", key)
 		}

--- a/internal/storage/reconciliations_test.go
+++ b/internal/storage/reconciliations_test.go
@@ -159,4 +159,14 @@ func TestReconciliationList(t *testing.T) {
 		require.Equal(t, reconciliations.Data[1].ID, r3.ID)
 	})
 
+	t.Run("with unsupported operator on createdAt", func(t *testing.T) {
+		_, err := store.ListReconciliations(context.Background(), GetReconciliationsQuery{
+			Options: PaginatedQueryOptions[ReconciliationsFilters]{
+				QueryBuilder: query.Exists("createdAt", true),
+			},
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidQuery)
+	})
+
 }


### PR DESCRIPTION
**Jira:** [EN-1208](https://formance-team.atlassian.net/browse/EN-1208) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

In both `reconciliationQueryContext` and `policyQueryContext`, the `createdAt` branch builds SQL via:

```go
fmt.Sprintf("created_at %s ?", query.DefaultComparisonOperatorsMapping[operator])
```

The go-libs query parser accepts `$match, $gte, $lte, $gt, $lt, $exists`, but `DefaultComparisonOperatorsMapping` has no entry for `$exists`. A filter like `{"$exists": "createdAt"}` resolves to an empty string and produces `created_at  ?` — a SQL syntax error surfaced as a **500** instead of a 400 validation error.

Not an injection vector (the mapping is a fixed map), but unvalidated input reaching SQL generation.

## Fix

Validate the operator against the mapping; unsupported operators return `ErrInvalidQuery`, which `handleServiceErrors` maps to a 400 `VALIDATION` response.

## Tests

Added `with unsupported operator on createdAt` cases to both `TestReconciliationList` and `TestPolicyList` (integration tests against dockerized PG, `-tags it`).

Part of the repository review (REVIEW.md, finding M1).

[EN-1208]: https://formance-team.atlassian.net/browse/EN-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ