### PR TITLE
feat(health): verify DB reachability + migration state at startup [EN-1209]

### DIFF
--- a/internal/api/module.go
+++ b/internal/api/module.go
@@ -25,9 +25,9 @@ const (
 func healthCheckModule() fx.Option {
 	return fx.Options(
 		health.Module(),
-		health.ProvideHealthCheck(func() health.NamedCheck {
-			return health.NewNamedCheck("default", health.CheckFn(func(ctx context.Context) error {
-				return nil
+		health.ProvideHealthCheck(func(store *storage.Storage) health.NamedCheck {
+			return health.NewNamedCheck("database", health.CheckFn(func(ctx context.Context) error {
+				return store.Ping(ctx)
 			}))
 		}),
 	)

--- a/internal/api/module.go
+++ b/internal/api/module.go
@@ -25,9 +25,16 @@ const (
 func healthCheckModule() fx.Option {
 	return fx.Options(
 		health.Module(),
-		health.ProvideHealthCheck(func(store *storage.Storage) health.NamedCheck {
-			return health.NewNamedCheck("database", health.CheckFn(func(ctx context.Context) error {
-				return store.Ping(ctx)
+		health.ProvideHealthCheck(func() health.NamedCheck {
+			// Intentionally a process-only liveness check: it must NOT ping the
+			// database or any dependency. The operator wires /_healthcheck to
+			// BOTH the liveness and readiness probes, and the liveness probe
+			// restarts the pod after ~40s of failures. Checking the DB here
+			// would turn a transient DB outage into a restart storm across all
+			// replicas. DB reachability and migration state are verified once at
+			// startup (storage OnStart hook), which fails fast instead.
+			return health.NewNamedCheck("default", health.CheckFn(func(ctx context.Context) error {
+				return nil
 			}))
 		}),
 	)

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Store interface {
-	Ping() error
+	Ping(ctx context.Context) error
 	CreatePolicy(ctx context.Context, policy *models.Policy) error
 	DeletePolicy(ctx context.Context, id uuid.UUID) error
 	GetPolicy(ctx context.Context, id uuid.UUID) (*models.Policy, error)

--- a/internal/api/service/service_test.go
+++ b/internal/api/service/service_test.go
@@ -94,7 +94,7 @@ func newMockStore() *mockStore {
 	return &mockStore{}
 }
 
-func (s *mockStore) Ping() error {
+func (s *mockStore) Ping(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/storage/migrations/migrations.go
+++ b/internal/storage/migrations/migrations.go
@@ -14,6 +14,13 @@ func Migrate(ctx context.Context, db *bun.DB) error {
 	return migrator.Up(ctx, db)
 }
 
+func IsUpToDate(ctx context.Context, db *bun.DB) (bool, error) {
+	migrator := migrations.NewMigrator()
+	registerMigrations(migrator)
+
+	return migrator.IsUpToDate(ctx, db)
+}
+
 func registerMigrations(migrator *migrations.Migrator) {
 	migrator.RegisterMigrations(
 		migrations.Migration{

--- a/internal/storage/module.go
+++ b/internal/storage/module.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/formancehq/go-libs/bun/bunconnect"
 	"github.com/formancehq/go-libs/logging"
+	"github.com/formancehq/reconciliation/internal/storage/migrations"
+	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
 	"go.uber.org/fx"
 )
@@ -18,12 +20,22 @@ func Module(connectionOptions bunconnect.ConnectionOptions, debug bool) fx.Optio
 		fx.Provide(func(db *bun.DB) *Storage {
 			return NewStorage(db)
 		}),
-		fx.Invoke(func(lc fx.Lifecycle, repo *Storage) {
+		fx.Invoke(func(lc fx.Lifecycle, repo *Storage, db *bun.DB) {
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
 					logging.FromContext(ctx).Debug("Ping database...")
+					if err := repo.Ping(ctx); err != nil {
+						return errors.Wrap(err, "failed to ping database")
+					}
 
-					// TODO: Check migrations state and panic if migrations are not applied
+					logging.FromContext(ctx).Debug("Checking migrations state...")
+					upToDate, err := migrations.IsUpToDate(ctx, db)
+					if err != nil {
+						return errors.Wrap(err, "failed to check migrations state")
+					}
+					if !upToDate {
+						return errors.New("database is not up to date, please run migrations")
+					}
 
 					return nil
 				},

--- a/internal/storage/ping.go
+++ b/internal/storage/ping.go
@@ -1,5 +1,7 @@
 package storage
 
-func (s *Storage) Ping() error {
-	return s.db.Ping()
+import "context"
+
+func (s *Storage) Ping(ctx context.Context) error {
+	return s.db.PingContext(ctx)
 }


### PR DESCRIPTION
**Jira:** [EN-1209](https://formance-team.atlassian.net/browse/EN-1209) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

- The storage `OnStart` hook logged `Ping database...` but never pinged anything, and the `TODO: Check migrations state` was unimplemented: a service pointed at an unreachable or unmigrated database started successfully and failed on the first query.
- `Storage.Ping()` existed but was dead code and took no context (no timeout/cancellation possible).

## Fix

- `Storage.Ping(ctx)` (uses `db.PingContext`)
- Storage `OnStart`: pings the DB, then fails fast if `migrations.IsUpToDate` reports pending migrations (new helper in the migrations package, reusing the go-libs migrator)
- `service.Store` interface updated accordingly

The `/_healthcheck` endpoint is intentionally **left as a process-only check** and does **not** ping the database. The operator wires `/_healthcheck` to **both** the liveness and readiness probes (`applications.DefaultLiveness`/`DefaultReadiness`, default path `/_healthcheck`), and the liveness probe restarts the pod after ~40s of failures (`FailureThreshold: 20` × `PeriodSeconds: 2`). Pinging the DB from the health check would turn a transient PostgreSQL outage into a restart storm across all replicas, since restarting the process cannot recover a down dependency. This matches the other stack services — webhooks/wallets return 200 unconditionally, and ledger checks migration state once then caches it rather than pinging live.

DB validity is therefore enforced once at startup (fail-fast `OnStart`), not on every probe.

> Note: properly serving the original "LB keeps routing to broken instances" concern would require splitting the probes in the operator (DB-checking *readiness* endpoint + process-only *liveness* endpoint) — that's a separate operator change, intentionally out of scope here.

Note: with the pgx driver, a missing version table surfaces as an error from `IsUpToDate` rather than the dedicated `ErrMissingVersionTable` (go-libs only maps lib/pq error codes) — either way startup fails fast, which is the intent.

## Tests

`go test ./...` and `go test -tags it ./internal/storage/` green.

Part of the repository review (REVIEW.md, finding M2).

[EN-1209]: https://formance-team.atlassian.net/browse/EN-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
