### PR TITLE
fix(sdk): replace 24h HTTP client timeout with 5 minutes [EN-1210]

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,7 +43,10 @@ func stackClientModule(cmd *cobra.Command) fx.Option {
 			}
 			underlyingHTTPClient := &http.Client{
 				Transport: otlp.NewRoundTripper(http.DefaultTransport, service.IsDebug(cmd)),
-				Timeout:   24 * time.Hour,
+				// Upper bound for ledger/payments calls (aggregated balance
+				// queries can be slow on large ledgers) and for the oauth2
+				// token exchange, which runs outside any request context.
+				Timeout: 5 * time.Minute,
 			}
 			return sdk.New(
 				sdk.WithClient(


### PR DESCRIPTION
**Jira:** [EN-1210](https://formance-team.atlassian.net/browse/EN-1210) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

`cmd/serve.go` configures the SDK HTTP client with `Timeout: 24 * time.Hour` — effectively no timeout for calls to the ledger and payments services. Request-context cancellation mitigates this for HTTP-triggered work, but the oauth2 token exchange uses `context.Background()` and is not covered by any request context: a hung upstream can pin connections/goroutines for a day.

## Fix

5-minute timeout — a generous upper bound for `V2GetBalancesAggregated` point-in-time queries on large ledgers, while still bounding token-exchange and stuck-connection scenarios. Happy to tighten further if production latencies allow.

Part of the repository review (REVIEW.md, finding M3).

[EN-1210]: https://formance-team.atlassian.net/browse/EN-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ