### PR TITLE
fix(api): bound the query-builder request body size [EN-1211]

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -9,8 +9,13 @@ import (
 	"github.com/formancehq/reconciliation/internal/storage"
 )
 
+// maxQueryBuilderBodySize bounds the optional request body carrying query
+// filters on list endpoints: without it, io.ReadAll would buffer an
+// arbitrarily large body in memory.
+const maxQueryBuilderBodySize = 1 << 20 // 1MiB
+
 func getQueryBuilder(r *http.Request) (query.Builder, error) {
-	data, err := io.ReadAll(r.Body)
+	data, err := io.ReadAll(http.MaxBytesReader(nil, r.Body, maxQueryBuilderBodySize))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetQueryBuilderBodyLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("body within limit", func(t *testing.T) {
+		t.Parallel()
+
+		body := `{"$match": {"id": "foo"}}`
+		req := httptest.NewRequest(http.MethodGet, "/reconciliations", strings.NewReader(body))
+
+		qb, err := getQueryBuilder(req)
+		require.NoError(t, err)
+		require.NotNil(t, qb)
+	})
+
+	t.Run("oversized body is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		body := bytes.Repeat([]byte("a"), maxQueryBuilderBodySize+1)
+		req := httptest.NewRequest(http.MethodGet, "/reconciliations", bytes.NewReader(body))
+
+		_, err := getQueryBuilder(req)
+		require.Error(t, err)
+
+		var maxBytesErr *http.MaxBytesError
+		require.ErrorAs(t, err, &maxBytesErr)
+	})
+}


### PR DESCRIPTION
**Jira:** [EN-1211](https://formance-team.atlassian.net/browse/EN-1211) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

`getQueryBuilder` (internal/api/utils.go) called `io.ReadAll(r.Body)` with no size limit on the optional request body of the list endpoints (`GET /reconciliations`, `GET /policies`). An authenticated client could send a multi-GB body and exhaust the service's memory.

## Fix

Wrap the body in `http.MaxBytesReader` capped at 1MiB — orders of magnitude above any legitimate query filter. Oversized bodies surface as an error mapped to a 400 by the handlers.

## Tests

New `TestGetQueryBuilderBodyLimit`: a body within the limit parses fine; an oversized body returns `*http.MaxBytesError`.

Part of the repository review (REVIEW.md, finding M4).

[EN-1211]: https://formance-team.atlassian.net/browse/EN-1211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ