### PR TITLE
chore: align go.mod with the Go 1.26 toolchain used by CI and the dev shell [EN-1212]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/formancehq/reconciliation
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.5.1


### PR DESCRIPTION
**Jira:** [EN-1212](https://formance-team.atlassian.net/browse/EN-1212) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

Commit 1d5d3e2 ("chore: upgrade Go to 1.26 and modernize flake.nix") switched the dev shell to `go_1_26`, but `go.mod` still declared `go 1.25.0`. CI runs everything through `nix develop`, so the module's declared Go version no longer matched the compiler actually building and testing the project.

## Fix

`go 1.25.0` → `go 1.26.0` in go.mod (`go mod tidy` produced no other changes).

Part of the repository review (REVIEW.md, finding M6).

[EN-1212]: https://formance-team.atlassian.net/browse/EN-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ