### PR TITLE
refactor(service): remove unreachable code in Reconciliation [EN-1213]

### DIFF
--- a/internal/api/service/reconciliation.go
+++ b/internal/api/service/reconciliation.go
@@ -84,35 +84,15 @@ func (s *Service) Reconciliation(ctx context.Context, policyID string, req *Reco
 		DriftBalances:        make(map[string]*big.Int),
 	}
 
-	var reconciliationError bool
-	if len(paymentsBalances) != len(ledgerBalances) {
-		res.Status = models.ReconciliationNotOK
-		res.Error = "different number of assets"
-		return res, nil
-	}
-
-	if !reconciliationError {
-		for asset, ledgerBalance := range ledgerBalances {
-			err := s.computeDrift(res, asset, ledgerBalance, paymentsBalances[asset])
-			if err != nil {
-				res.Status = models.ReconciliationNotOK
-				if res.Error == "" {
-					res.Error = err.Error()
-				} else {
-					res.Error = res.Error + "; " + err.Error()
-				}
-			}
-		}
-
-		for asset, paymentBalance := range paymentsBalances {
-			if _, ok := res.DriftBalances[asset]; ok {
-				// Already computed
-				continue
-			}
-
-			err := s.computeDrift(res, asset, ledgerBalances[asset], paymentBalance)
-			if err != nil {
-				res.Status = models.ReconciliationNotOK
+	// harmonizeBalances guarantees both maps share the same key set, so a
+	// single pass over ledgerBalances covers every asset.
+	for asset, ledgerBalance := range ledgerBalances {
+		err := s.computeDrift(res, asset, ledgerBalance, paymentsBalances[asset])
+		if err != nil {
+			res.Status = models.ReconciliationNotOK
+			if res.Error == "" {
+				res.Error = err.Error()
+			} else {
 				res.Error = res.Error + "; " + err.Error()
 			}
 		}


### PR DESCRIPTION
**Jira:** [EN-1213](https://formance-team.atlassian.net/browse/EN-1213) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

After `harmonizeBalances()` both balance maps are guaranteed to share the same key set, which makes three blocks in `Service.Reconciliation` unreachable:

- the `len(paymentsBalances) != len(ledgerBalances)` early return ("different number of assets")
- the `reconciliationError` flag — declared, never set to `true`, so `if !reconciliationError` is always taken
- the entire second loop over `paymentsBalances`: after the first loop every asset is already in `DriftBalances`, so the `continue` always fires. Its error concatenation also lacked the empty-string guard and would have produced errors starting with `"; "` had it ever run.

This function already had one production bug (#62); less code to misread matters here.

## Fix

Single loop over `ledgerBalances` with a comment stating the harmonization invariant. **No behavior change** — all existing tests pass unchanged.

Note: independent from #74 (drift semantics), touches different lines of the same function; both merge cleanly in either order.

Part of the repository review (REVIEW.md, finding L1).

[EN-1213]: https://formance-team.atlassian.net/browse/EN-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ