### PR TITLE
fix(storage): rename CreateReconciation to CreateReconciliation [EN-1214]

### DIFF
--- a/internal/api/service/reconciliation.go
+++ b/internal/api/service/reconciliation.go
@@ -118,7 +118,7 @@ func (s *Service) Reconciliation(ctx context.Context, policyID string, req *Reco
 		}
 	}
 
-	if err := s.store.CreateReconciation(ctx, res); err != nil {
+	if err := s.store.CreateReconciliation(ctx, res); err != nil {
 		return nil, newStorageError(err, "failed to create reconciliation")
 	}
 

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -19,7 +19,7 @@ type Store interface {
 	GetPolicy(ctx context.Context, id uuid.UUID) (*models.Policy, error)
 	ListPolicies(ctx context.Context, q storage.GetPoliciesQuery) (*bunpaginate.Cursor[models.Policy], error)
 
-	CreateReconciation(ctx context.Context, reco *models.Reconciliation) error
+	CreateReconciliation(ctx context.Context, reco *models.Reconciliation) error
 	GetReconciliation(ctx context.Context, id uuid.UUID) (*models.Reconciliation, error)
 	ListReconciliations(ctx context.Context, q storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error)
 }

--- a/internal/api/service/service_test.go
+++ b/internal/api/service/service_test.go
@@ -121,7 +121,7 @@ func (s *mockStore) ListPolicies(ctx context.Context, q storage.GetPoliciesQuery
 	return nil, nil
 }
 
-func (s *mockStore) CreateReconciation(ctx context.Context, reco *models.Reconciliation) error {
+func (s *mockStore) CreateReconciliation(ctx context.Context, reco *models.Reconciliation) error {
 	return nil
 }
 

--- a/internal/storage/reconciliations.go
+++ b/internal/storage/reconciliations.go
@@ -12,7 +12,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func (s *Storage) CreateReconciation(ctx context.Context, reco *models.Reconciliation) error {
+func (s *Storage) CreateReconciliation(ctx context.Context, reco *models.Reconciliation) error {
 	_, err := s.db.NewInsert().
 		Model(reco).
 		Exec(ctx)

--- a/internal/storage/reconciliations_test.go
+++ b/internal/storage/reconciliations_test.go
@@ -61,7 +61,7 @@ var (
 
 func insertReconciliations(t *testing.T, store *Storage, reconciliations ...*models.Reconciliation) {
 	for _, reconciliation := range reconciliations {
-		err := store.CreateReconciation(context.Background(), reconciliation)
+		err := store.CreateReconciliation(context.Background(), reconciliation)
 		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
**Jira:** [EN-1214](https://formance-team.atlassian.net/browse/EN-1214) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

Typo in the public storage API method name (missing 'l'), propagated through the `service.Store` interface, its test mock, and call sites. Internal-only symbol — mechanical rename, no behavior change.

Part of the repository review (REVIEW.md, finding L2).

[EN-1214]: https://formance-team.atlassian.net/browse/EN-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ