### PR TITLE
docs(openapi): align pageSize maximum with the implemented cap [EN-1215]

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -156,7 +156,7 @@ components:
         type: integer
         format: int64
         minimum: 1
-        maximum: 1000
+        maximum: 100
     Cursor:
       name: cursor
       in: query
@@ -256,7 +256,7 @@ components:
               type: integer
               format: int64
               minimum: 1
-              maximum: 1000
+              maximum: 100
               example: 15
             hasMore:
               type: boolean
@@ -287,7 +287,7 @@ components:
               type: integer
               format: int64
               minimum: 1
-              maximum: 1000
+              maximum: 100
               example: 15
             hasMore:
               type: boolean


### PR DESCRIPTION
**Jira:** [EN-1215](https://formance-team.atlassian.net/browse/EN-1215) — Epic: [EN-1199](https://formance-team.atlassian.net/browse/EN-1199)

## Problem

`openapi.yaml` declared `maximum: 1000` for the `pageSize` request parameter and for `pageSize` in cursor responses, but the implementation caps page sizes at `MaxPageSize = 100` (`internal/api/query.go`). Clients relying on the documented limit were silently capped at 100.

## Fix

`maximum: 1000` → `maximum: 100` (request parameter + both cursor response schemas). The `minimum: 1` already declared on the request parameter matches the validation added in #73.

Part of the repository review (REVIEW.md, finding L4).

[EN-1215]: https://formance-team.atlassian.net/browse/EN-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1199]: https://formance-team.atlassian.net/browse/EN-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ