### PR TITLE
fix: preserve filtered reconciliation cursors

### DIFF
--- a/internal/api/reconciliation_test.go
+++ b/internal/api/reconciliation_test.go
@@ -2,17 +2,20 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	sharedapi "github.com/formancehq/go-libs/api"
 	"github.com/formancehq/go-libs/auth"
+	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
 	"github.com/formancehq/reconciliation/internal/api/service"
 	"github.com/formancehq/reconciliation/internal/models"
@@ -469,4 +472,36 @@ func TestGetReconciliation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListReconciliationsWithFilteredCursor(t *testing.T) {
+	backend, mockService := newTestingBackend(t)
+
+	params := url.Values{}
+	params.Set("pageSize", "1")
+	params.Set("query", `{"$gte":{"createdAt":"2026-07-09T09:28:24.461Z"}}`)
+	firstRequest := httptest.NewRequest(http.MethodGet, "/reconciliations?"+params.Encode(), nil)
+	options, err := getPaginatedQueryOptionsReconciliations(firstRequest)
+	require.NoError(t, err)
+
+	query := storage.NewGetReconciliationsQuery(*options)
+	query.Offset = 1
+	cursor := (*bunpaginate.OffsetPaginatedQuery[storage.PaginatedQueryOptions[storage.ReconciliationsFilters]])(&query).EncodeAsCursor()
+
+	mockService.EXPECT().
+		ListReconciliations(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, actual storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error) {
+			require.Equal(t, uint64(1), actual.Offset)
+			require.Equal(t, uint64(1), actual.PageSize)
+			actualQuery, err := json.Marshal(actual.Options.QueryBuilder)
+			require.NoError(t, err)
+			require.JSONEq(t, `{"$gte":{"createdAt":"2026-07-09T09:28:24.461Z"}}`, string(actualQuery))
+			return &bunpaginate.Cursor[models.Reconciliation]{}, nil
+		})
+
+	secondRequest := httptest.NewRequest(http.MethodGet, "/reconciliations?cursor="+url.QueryEscape(cursor), nil)
+	recorder := httptest.NewRecorder()
+	listReconciliationsHandler(backend).ServeHTTP(recorder, secondRequest)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
 }

--- a/internal/api/reconciliation_test.go
+++ b/internal/api/reconciliation_test.go
@@ -475,34 +475,57 @@ func TestGetReconciliation(t *testing.T) {
 	}
 }
 
-func TestListReconciliationsWithFilteredCursor(t *testing.T) {
-	backend, mockService := newTestingBackend(t)
+func TestListReconciliationsWithCursor(t *testing.T) {
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "with query",
+			query: `{"$gte":{"createdAt":"2026-07-09T09:28:24.461Z"}}`,
+		},
+		{
+			name: "without query",
+		},
+	}
 
-	params := url.Values{}
-	params.Set("pageSize", "1")
-	params.Set("query", `{"$gte":{"createdAt":"2026-07-09T09:28:24.461Z"}}`)
-	firstRequest := httptest.NewRequest(http.MethodGet, "/reconciliations?"+params.Encode(), nil)
-	options, err := getPaginatedQueryOptionsReconciliations(firstRequest)
-	require.NoError(t, err)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			backend, mockService := newTestingBackend(t)
 
-	query := storage.NewGetReconciliationsQuery(*options)
-	query.Offset = 1
-	cursor := (*bunpaginate.OffsetPaginatedQuery[storage.PaginatedQueryOptions[storage.ReconciliationsFilters]])(&query).EncodeAsCursor()
-
-	mockService.EXPECT().
-		ListReconciliations(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, actual storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error) {
-			require.Equal(t, uint64(1), actual.Offset)
-			require.Equal(t, uint64(1), actual.PageSize)
-			actualQuery, err := json.Marshal(actual.Options.QueryBuilder)
+			params := url.Values{}
+			params.Set("pageSize", "1")
+			if testCase.query != "" {
+				params.Set("query", testCase.query)
+			}
+			firstRequest := httptest.NewRequest(http.MethodGet, "/reconciliations?"+params.Encode(), nil)
+			options, err := getPaginatedQueryOptionsReconciliations(firstRequest)
 			require.NoError(t, err)
-			require.JSONEq(t, `{"$gte":{"createdAt":"2026-07-09T09:28:24.461Z"}}`, string(actualQuery))
-			return &bunpaginate.Cursor[models.Reconciliation]{}, nil
+
+			query := storage.NewGetReconciliationsQuery(*options)
+			query.Offset = 1
+			cursor := (*bunpaginate.OffsetPaginatedQuery[storage.PaginatedQueryOptions[storage.ReconciliationsFilters]])(&query).EncodeAsCursor()
+
+			mockService.EXPECT().
+				ListReconciliations(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, actual storage.GetReconciliationsQuery) (*bunpaginate.Cursor[models.Reconciliation], error) {
+					require.Equal(t, uint64(1), actual.Offset)
+					require.Equal(t, uint64(1), actual.PageSize)
+					actualQuery, err := json.Marshal(actual.Options.QueryBuilder)
+					require.NoError(t, err)
+					if testCase.query == "" {
+						require.Equal(t, "null", string(actualQuery))
+					} else {
+						require.JSONEq(t, testCase.query, string(actualQuery))
+					}
+					return &bunpaginate.Cursor[models.Reconciliation]{}, nil
+				})
+
+			secondRequest := httptest.NewRequest(http.MethodGet, "/reconciliations?cursor="+url.QueryEscape(cursor), nil)
+			recorder := httptest.NewRecorder()
+			listReconciliationsHandler(backend).ServeHTTP(recorder, secondRequest)
+
+			require.Equal(t, http.StatusOK, recorder.Code)
 		})
-
-	secondRequest := httptest.NewRequest(http.MethodGet, "/reconciliations?cursor="+url.QueryEscape(cursor), nil)
-	recorder := httptest.NewRecorder()
-	listReconciliationsHandler(backend).ServeHTTP(recorder, secondRequest)
-
-	require.Equal(t, http.StatusOK, recorder.Code)
+	}
 }

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -28,8 +28,9 @@ type PaginatedQueryOptions[T any] struct {
 
 func (opts *PaginatedQueryOptions[T]) UnmarshalJSON(data []byte) error {
 	type base struct {
-		PageSize uint64 `json:"pageSize"`
-		Options  T      `json:"options"`
+		PageSize uint64          `json:"pageSize"`
+		Options  T               `json:"options"`
+		RawQB    json.RawMessage `json:"qb"`
 	}
 
 	var value base
@@ -40,12 +41,12 @@ func (opts *PaginatedQueryOptions[T]) UnmarshalJSON(data []byte) error {
 	opts.PageSize = value.PageSize
 	opts.Options = value.Options
 
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+	if len(value.RawQB) == 0 || string(value.RawQB) == "null" {
+		opts.QueryBuilder = nil
+		return nil
 	}
 
-	queryBuilder, err := query.ParseJSON(string(raw["qb"]))
+	queryBuilder, err := query.ParseJSON(string(value.RawQB))
 	if err != nil {
 		return err
 	}

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/go-libs/query"
@@ -23,6 +24,34 @@ type PaginatedQueryOptions[T any] struct {
 	QueryBuilder query.Builder `json:"qb"`
 	PageSize     uint64        `json:"pageSize"`
 	Options      T             `json:"options"`
+}
+
+func (opts *PaginatedQueryOptions[T]) UnmarshalJSON(data []byte) error {
+	type base struct {
+		PageSize uint64 `json:"pageSize"`
+		Options  T      `json:"options"`
+	}
+
+	var value base
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	opts.PageSize = value.PageSize
+	opts.Options = value.Options
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	queryBuilder, err := query.ParseJSON(string(raw["qb"]))
+	if err != nil {
+		return err
+	}
+	opts.QueryBuilder = queryBuilder
+
+	return nil
 }
 
 func (opts PaginatedQueryOptions[T]) WithQueryBuilder(qb query.Builder) PaginatedQueryOptions[T] {


### PR DESCRIPTION
## Summary
- restore the query builder while decoding pagination cursors
- add regression coverage for filtered reconciliation cursors

## Testing
- go test ./...