### PR TITLE
feat(reconciliation): add multi-source rules and audit timelines

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -41,9 +41,13 @@ generate-ledger-proto:
         proto/ledger/restore.proto \
         proto/ledger/proposal.proto
 
-# Run tests with race detector and coverage
+# Run hermetic tests with race detector and coverage
 tests:
-    go test -race -covermode atomic -tags it ./...
+    go test -race -covermode atomic ./...
+
+# Run the serial integration suite against a live Ledger v3 on localhost:8888
+tests-integration:
+    go test -race -covermode atomic -tags it -p 1 ./...
 
 # Build the binary locally
 build:

--- a/cmd/ledger.go
+++ b/cmd/ledger.go
@@ -43,9 +43,9 @@ func addLedgerFlags(flags *pflag.FlagSet) {
 const reconciliationEventsSinkName = "reconciliation"
 
 // reconciliationSinkEventTypes are the ledger event types that carry alert
-// transitions: lifecycle moves (open/ack/resolve/accept/auto-resolve) are
-// COMMITTED_TRANSACTION (marker move + account_metadata), snooze/unsnooze are
-// SAVED_METADATA/DELETED_METADATA. Consumers filter on event.ledger == control.
+// transitions. Current lifecycle and snooze/unsnooze writes are
+// COMMITTED_TRANSACTION events because they append activity atomically. Metadata
+// events remain subscribed for compatibility with older or direct writers.
 func reconciliationSinkEventTypes() []commonpb.EventType {
 	return []commonpb.EventType{
 		commonpb.EventType_COMMITTED_TRANSACTION,

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ The internal kernel that powers it (CEL over a typed object model + `Source` abs
 ## Documentation
 
 ### [Product (`prd/`)](./prd/README.md)
-The full PRD (v0.5), positioning, scope, phasing, and the two architecture decision records that pin down the most expensive technical choices.
+The full PRD (v0.5), positioning, scope, phasing, and the architecture decision records that pin down the most expensive technical choices.
 
 ### [Technical (`technical/`)](./technical/README.md)
 Architecture, the API reference, the lifecycle workflows, the template catalog, and how to run the stack locally.
@@ -31,9 +31,11 @@ V1.1+ feature carve-outs and EE+ "Finance Ops" notes — not committed scope.
 | **Lifecycle workflows** | [technical/workflows.md](./technical/workflows.md) |
 | **Template catalog** | [technical/templates.md](./technical/templates.md) |
 | **Architecture overview** | [technical/architecture.md](./technical/architecture.md) |
+| **Ledger v3 storage model** | [technical/ledger-v3-storage.md](./technical/ledger-v3-storage.md) |
 | **End-to-end demo UI** | [`../../poc-reconciliation-demo`](../../poc-reconciliation-demo) (sibling repo) |
 | **ADR-001 — CEL kernel choice** | [prd/adr-001-cel-kernel.md](./prd/adr-001-cel-kernel.md) |
 | **ADR-002 — PIT consistency model** | [prd/adr-002-pit-consistency.md](./prd/adr-002-pit-consistency.md) |
+| **ADR-004 — multi-source comparisons** | [prd/adr-004-multi-source-comparisons.md](./prd/adr-004-multi-source-comparisons.md) |
 
 ---
 
@@ -49,14 +51,27 @@ V1.1+ feature carve-outs and EE+ "Finance Ops" notes — not committed scope.
 | 6 | API endpoints + OpenAPI | ✅ shipped |
 | 7 | End-to-end demo UI ([poc-reconciliation-demo](../../poc-reconciliation-demo)) — replaces the planned dockertest harness | ✅ shipped |
 | 8 | V1 GA additions — event delivery via the ledger events sink ✅ · in-process cron scheduler ✅ (single-instance) · email digest / fctl / EE gating / metering 🚧 | 🚧 in progress |
+| 9 | V2 additive API — `balance_equation`, `exchange_rate_bounds`, `source_consensus`, and `coverage_ratio_bounds`, isolated from V1 persisted contracts | ✅ implemented |
+
+## V2 compatibility boundary
+
+V2 is additive. Existing V1 rules remain on the unprefixed `/rules` and `/alerts` routes and retain
+their persisted `source_parity.left` / `.right` fields and `leftSource` / `leftBalance` /
+`rightSource` / `rightBalance` evidence. V2 resources live under `/v2`, carry
+`contractVersion: 2`, and use named `sources[]` entries instead of positional left/right fields.
+There is no automatic rewrite or backfill of V1 rules, captures, alerts, or accepted evidence
+snapshots. See [the API reference](./technical/api.md#v1v2-coexistence) and
+[ADR-004](./prd/adr-004-multi-source-comparisons.md).
 
 > **Ledger-native migration (branch `feat/reconciliation-ledger-v3`).** The storage layer above was
 > subsequently reshaped: reconciliation is now **Postgres-free**, running on a Ledger v3
-> control-ledger (`_recon`), reading the reconciled ledgers at query checkpoints, and delivering
+> control-ledger (default name `reconciliation`; `_recon` in design shorthand), reading the reconciled ledgers live, recording an immutable capture for
+> every evaluation, and delivering
 > events via the ledger's native sink. Steps 2 (migrations/models → ledger accounts), 5 (event-log →
 > ledger log), and the reads are superseded — see the
-> [migration log](./drafts/ledger-v3-migration-log.md) and [architecture.md](./technical/architecture.md).
+> [migration log](./drafts/ledger-v3-migration-log.md), [architecture.md](./technical/architecture.md),
+> and the consolidated [Ledger v3 storage model](./technical/ledger-v3-storage.md).
 
-Recon reads data-ledgers via the gRPC `AggregateVolumes` / `ListAccounts` at a query checkpoint
-(ADR-002), not the REST `/aggregate/balances` PIT path — so [formancehq/ledger#1416](https://github.com/formancehq/ledger/issues/1416)
+Recon reads data-ledgers live via gRPC `AggregateVolumes` / `ListAccounts` (ADR-003, superseding
+ADR-002), not the REST `/aggregate/balances` PIT path — so [formancehq/ledger#1416](https://github.com/formancehq/ledger/issues/1416)
 (PIT + metadata empty under `ACCOUNT_METADATA_HISTORY: DISABLED`) is off recon's read path.

--- a/docs/drafts/ledger-v3-migration-log.md
+++ b/docs/drafts/ledger-v3-migration-log.md
@@ -11,6 +11,13 @@ the [RFC](./rfc-ledger-native-storage.md) and [ADR-002](../prd/adr-002-pit-consi
 
 ## 👋 Handoff — resume here
 
+> **Current implementation note (2026-07-18).** This file is a chronological development log, so
+> older sections intentionally preserve decisions that were later superseded. The current branch
+> adds the `ACTIVITY` asset and rule-scoped activity accounts, stores lifecycle and snooze/unsnooze
+> history as transactions, and exposes a combined rule timeline. The exact current chart, six
+> Numscript programs at `v2.0.0`, indexes, queries, and provisioning behavior are consolidated in
+> [Ledger v3 storage model](../technical/ledger-v3-storage.md).
+
 **🎉 Checkpoint alternative COMPLETE (2026-07-08, ADR-003).** Query checkpoints **removed** — recon
 reads its data ledgers **live** and records each evaluation as an immutable `_recon` **capture**
 transaction (audit-grade: receipt-signed, append-only; positive assurance on pass, break evidence on
@@ -1262,14 +1269,18 @@ sweep) — kept uniform to avoid forking the address shape/code path for a cosme
 
 ## Proto re-sync procedure (F5)
 
-The ledger protos are **copied**, not submoduled (mirrors ledger-connect). To update:
+The Ledger protos are **copied**, not submoduled. To update:
 
-1. `cp <ledger-connect>/proto/ledger/*.proto proto/ledger/` (ledger-connect keeps them synced
-   to a ledger release — currently **v3.0.0-alpha.3**).
-2. Rewrite the module path: `sed -i '' 's#formancehq/ledger-connect/internal/ledgerpb#formancehq/reconciliation/internal/ledgerpb#g' proto/ledger/*.proto`.
-3. `just generate-ledger-proto` (regenerates `internal/ledgerpb/*`).
-4. Re-copy hand-written helpers if ledger-connect changed them:
-   `internal/ledgerpb/commonpb/{metadata,index,uint256}_helpers.go`.
-5. `go mod tidy && go build ./...`. Commit the regenerated output.
+1. Check out the target Ledger revision (currently the `release/v3.0` branch) and copy
+   `<ledger>/misc/proto/*.proto` to `proto/ledger/`.
+2. Rewrite every `go_package` prefix from
+   `github.com/formancehq/ledger/v3/internal/proto/` to
+   `github.com/formancehq/reconciliation/internal/ledgerpb/`.
+3. Run `nix develop --command just generate-ledger-proto`. The Nix shell pins `protoc`,
+   `protoc-gen-go`, `protoc-gen-go-grpc`, and `protoc-gen-go-vtproto`; the recipe replaces only
+   generated `*.pb.go` files, preserving hand-written helpers.
+4. Run `go mod tidy && go test ./...`, then the tagged live-ledger suite with `-p 1`.
+5. Verify `git diff --check` and review all protobuf/API shape changes before committing the
+   vendored definitions and regenerated output.
 
-Record the ledger version each sync targets in the commit message.
+Record the exact Ledger revision each sync targets in the commit message.

--- a/docs/prd/adr-003-checkpoint-anchor-and-crosscheck.md
+++ b/docs/prd/adr-003-checkpoint-anchor-and-crosscheck.md
@@ -58,12 +58,11 @@ Direct math is now authoritative. The rendered CEL stays in `evidence.compiledCE
 ## 6. Decision C — audit-grade capture in `_recon`
 
 Every evaluation records an **immutable capture transaction** on the control ledger — the durable
-"what reconciled and when", recorded independently of the alert lifecycle. Its evidence roster is
-bounded to every failing outcome plus passing outcomes that automatically resolve an active alert;
-unrelated passes remain omitted.
+"what reconciled and when", recorded independently of the alert lifecycle. Its evidence roster
+retains every passing and failing outcome so the observed verdict can be reproduced later.
 
 - **Chart**: `capture:rule:{ruleId}:per:{period}` (NORMAL) bucket + `capture:pool:rule:{ruleId}` (NORMAL) mint source; asset `CAPTURE` (precision 0); numscript `capture` mints one `CAPTURE` from the pool into the bucket. `−balance(bucket, CAPTURE)` counts captures for the (rule, period); **one evaluation = one transaction**, so the bucket's transaction log is the period's ordered series of captures.
-- **Snapshot**: the observed state rides the **transaction metadata** (`COMMITTED_TRANSACTION`, self-describing: `type, rule_id, template_kind, period, evaluation_id, captured_at, verdict, trigger, evidence`). The transaction is immutable and receipt-signed — the audit record. The address is a bucket; the transaction carries the distinguishing context (`evaluation_id`, `captured_at`, `trigger`). A mixed-verdict capture may contain failing evidence for one fingerprint and successful resolution evidence for another because retention follows individual alert transitions, not the overall verdict.
+- **Snapshot**: the observed state rides the **transaction metadata** (`COMMITTED_TRANSACTION`, self-describing: `type, rule_id, template_kind, period, evaluation_id, captured_at, verdict, trigger, evidence`). The transaction is immutable and receipt-signed — the audit record. The address is a bucket; the transaction carries the distinguishing context (`evaluation_id`, `captured_at`, `trigger`). A mixed-verdict capture contains every fingerprint evaluated, independently of which outcomes mutate alerts.
 - **Idempotent** per (rule, period, evaluation): a gRPC retransmit dedups; a genuinely new evaluation gets a fresh key.
 
 This **revises the "evaluations non-durable" decision** (RFC §4.4.2): the durable record is the capture transaction (ledger-native, immutable), not a queryable Postgres evaluation table.

--- a/docs/prd/adr-004-multi-source-comparisons.md
+++ b/docs/prd/adr-004-multi-source-comparisons.md
@@ -1,0 +1,266 @@
+# ADR-004 — Versioned multi-source comparisons
+
+**Status:** Accepted for V2 implementation
+
+**Date:** 2026-07-18
+
+**Decision owners:** Reconciliation maintainers
+**Related:** [ADR-001](./adr-001-cel-kernel.md), [ADR-003](./adr-003-checkpoint-anchor-and-crosscheck.md), [template catalog](../technical/templates.md)
+
+## Context
+
+V1 `source_parity` answers one deliberately narrow question:
+
+```text
+abs(left - right) <= tolerance
+```
+
+Its `templateSpec.left` / `templateSpec.right` fields and
+`leftSource` / `leftBalance` / `rightSource` / `rightBalance` evidence are already persisted in
+rules, captures, alerts, and accepted evidence snapshots. Renaming or changing their meaning in
+place would make old evidence ambiguous and could break consumers that bind those exact keys.
+
+The next set of reconciliation controls requires more than two inputs and more than binary parity:
+
+- prove that two account sets sum to a third account set;
+- express a signed balance equation over several ledgers or metadata-backed balances;
+- compare balances denominated in different assets against an exchange-rate range;
+- preserve the exact values and arithmetic that produced the verdict.
+
+Extending V1 `source_parity` with an optional third side would not define the invariant. “All values
+are equal”, “compare each value with the first”, and “a signed sum is zero” are different statements.
+The exchange-rate case also needs asset precision and ratio semantics that do not exist in parity.
+
+## Decision
+
+### 1. Add a V2 contract; do not rewrite V1
+
+The unprefixed V1 routes and response bodies remain unchanged. V2 resources use `/v2` routes and an
+immutable persisted contract marker:
+
+- a missing marker decodes as V1 (`contractVersion = 1`);
+- new V1 resources are persisted with version 1;
+- V2 resources are persisted with version 2;
+- the route, not the client body, selects the contract version;
+- V2 responses expose read-only `contractVersion: 2`;
+- list, get, evaluation, capture, and alert actions are isolated by contract version.
+
+There is no automatic conversion, backfill, or evidence rewrite. A V1 rule remains executable as
+V1 for its lifetime. Creating the equivalent V2 rule is an explicit operator action.
+
+### 2. Use named aggregate sources
+
+All V2 operations share an ordered `sources[]` collection. Each entry is:
+
+```json
+{
+  "id": "book",
+  "label": "Customer balance",
+  "kind": "ledger",
+  "ledger": "main",
+  "query": { "$match": { "address": "accounts:customer:*" } },
+  "asset": "USD/2"
+}
+```
+
+`id` is the stable machine reference used by terms, fingerprints, and evidence. `label` is optional
+operator-facing text. `kind` defaults to `ledger`; `account_metadata` additionally requires
+`metadataKey`. Every source declares one `asset`, including ledger sources, so an operation never
+guesses how values with different denominations should align.
+
+V2 is aggregate-only. Per-account equations would require an explicit alignment key and missing-row
+semantics; per-account exchange rates would additionally require pair alignment. Those decisions are
+outside this ADR.
+
+### 3. Define `balance_equation` as a signed sum
+
+The operation is:
+
+```text
+abs(sum(coefficient_i * balance_i)) <= tolerance
+```
+
+For `A + B = C`, the coefficients are `+1`, `+1`, and `-1`:
+
+```json
+{
+  "sources": [
+    { "id": "a", "ledger": "main", "query": {}, "asset": "USD/2" },
+    { "id": "b", "ledger": "main", "query": {}, "asset": "USD/2" },
+    { "id": "c", "ledger": "control", "query": {}, "asset": "USD/2" }
+  ],
+  "terms": [
+    { "source": "a", "coefficient": 1 },
+    { "source": "b", "coefficient": 1 },
+    { "source": "c", "coefficient": -1 }
+  ],
+  "tolerance": "0"
+}
+```
+
+All sources must declare the same asset. Each source is referenced exactly once, and coefficients
+are non-zero signed integers. `tolerance` is a non-negative base-10 integer string in the declared
+asset's minor units. Strings avoid JSON-number precision loss in clients and persisted evidence.
+
+The outcome fingerprint is `asset:<asset>`.
+
+### 4. Define `exchange_rate_bounds` as an exact signed ratio
+
+The exchange-rate convention is:
+
+```text
+observed rate = quote asset major units / base asset major unit
+```
+
+For base minor-unit balance `B`, base precision `pB`, quote minor-unit balance `Q`, and quote
+precision `pQ`:
+
+```text
+observed rate = (Q * 10^pB) / (B * 10^pQ)
+```
+
+The implementation compares these integers by cross-multiplication. It does not convert to
+`float64`, round a displayed decimal, or take absolute values.
+
+Bounds use exactly one of these modes:
+
+```json
+{ "min": "1.075", "max": "1.125" }
+```
+
+or:
+
+```json
+{ "target": "1.10", "toleranceBps": 25 }
+```
+
+`min`, `max`, and `target` are positive plain-decimal strings with at most 18 fractional digits; a
+sign or exponent notation is not accepted. `toleranceBps` is an integer from 0 through 10,000.
+Bounds are inclusive. Target mode derives exact lower and upper bounds as:
+
+```text
+target * (10,000 - toleranceBps) / 10,000
+target * (10,000 + toleranceBps) / 10,000
+```
+
+The ratio remains signed. Two negative balances yield a positive rate; balances with opposite signs
+yield a negative rate and therefore fail positive bounds. A zero quote balance is a defined rate of
+zero and is evaluated normally. A zero base balance has no defined rate and produces a failed
+outcome with `undefinedReason: "base_balance_zero"`; it is not an engine error.
+
+The outcome fingerprint is `baseSource:<base-id>|quoteSource:<quote-id>`.
+
+### 5. Define `source_consensus` as symmetric agreement
+
+The operation is:
+
+```text
+all sources present AND max(balance_i) - min(balance_i) <= tolerance
+```
+
+All sources declare the same asset. A missing declared ledger asset remains `balance: "0"` and
+`present: false` in evidence but makes the consensus outcome fail. There is no quorum or privileged
+reference source: every declared source participates, and the minimum/maximum pair proves the widest
+disagreement. The outcome fingerprint is `asset:<asset>`.
+
+### 6. Define `coverage_ratio_bounds` as a ratio of portfolios
+
+The operation is:
+
+```text
+minRatio <= sum(numerator coefficient_i * balance_i)
+           / sum(denominator coefficient_j * balance_j) <= maxRatio
+```
+
+Every source declares the same asset and is assigned exactly once to one portfolio. Both portfolios
+are non-empty and accept non-zero signed integer coefficients. Bounds use the same exact explicit or
+target-plus-basis-points shapes as `exchange_rate_bounds`. A zero denominator total produces a failed
+outcome with `undefinedReason: "denominator_total_zero"`; it is not an engine error. The outcome
+fingerprint is `asset:<asset>`.
+
+### 7. Preserve exact, self-describing V2 evidence
+
+Every V2 evidence object carries `schemaVersion: 2` and an `operation` discriminator. Source entries
+are keyed by their stable `id` and retain the declared asset, effective kind, observed balance as a
+base-10 integer string, and whether that asset was present.
+
+Equation evidence records coefficients, contributions, residual, absolute residual, and tolerance.
+Exchange-rate evidence records base and quote snapshots and the exact observed rate. Consensus
+evidence records the minimum and maximum source/value pair, full spread, and missing sources.
+Coverage evidence records both portfolio totals, every contribution, and the exact reduced ratio.
+Each operation retains its canonical `compiledCEL`; undefined ratios omit the observed value and
+carry a typed `undefinedReason`.
+
+The V2 CEL financial built-ins are backed by exact `big.Int` / `big.Rat` arithmetic. They do not use
+binary floating point. The rule and evidence retain `compiledCEL` as the canonical explanation and
+cross-check surface.
+
+V2 evidence never emits the V1 `left*` or `right*` keys.
+
+### 8. Bound and validate the contract
+
+- `sources` contains between 2 and 32 entries; `exchange_rate_bounds` requires exactly two.
+- IDs are unique and match `^[A-Za-z][A-Za-z0-9_-]{0,63}$`.
+- Every query is validated against its ledger before the rule is persisted.
+- A ledger source missing its declared asset resolves to balance `0` with `present: false`.
+  `source_consensus` additionally requires every source to be present.
+- Missing or non-integer `account_metadata` values remain evaluation errors; they are not silent zero.
+- Validation errors use source IDs or labels for people and retain machine paths such as
+  `sources[1].asset` for clients.
+
+## Consequences
+
+### Positive
+
+- V1 persisted rules and evidence remain readable without migration.
+- Named sources are stable when a control grows beyond two inputs.
+- Signed equations state the mathematical invariant instead of inferring it from position.
+- Exact integer and rational arithmetic is deterministic across platforms and SDK languages.
+- Evidence is sufficient to reproduce a verdict without re-reading mutable ledger state.
+
+### Costs and limitations
+
+- V1 and V2 handlers, schemas, and compatibility tests must coexist.
+- V2 sources declare one asset each; a multi-asset control needs separate rules.
+- Live reads across sources are sequential rather than a certifiable atomic multi-ledger cut.
+  Tolerances or rate bounds must account for acceptable ingestion skew.
+- V2 does not provide arbitrary expression trees, dynamic FX feeds, weighted decimal coefficients,
+  or per-account alignment.
+
+## Alternatives considered
+
+### Extend `source_parity` with `sources[]`
+
+Rejected. It would overload a stable binary contract and still leave multi-source semantics
+ambiguous. It also cannot describe `A + B = C` without adding a second expression language.
+
+### Replace V1 fields in place
+
+Rejected. Persisted rules, captures, alerts, acceptance snapshots, tests, and external consumers may
+depend on the exact existing keys.
+
+### Expose raw CEL
+
+Rejected for this surface. Raw CEL is harder to validate, document, meter, and reproduce safely.
+The four V2 operations cover distinct reconciliation jobs with typed contracts.
+
+### Use floating-point exchange rates
+
+Rejected. Binary floating point introduces boundary-dependent verdicts and cannot safely preserve
+large ledger balances. Cross-multiplied integers provide exact comparisons.
+
+### Make consensus quorum configurable
+
+Rejected for the current contract. A quorum can allow a missing or stale record to disappear from
+the invariant precisely when it matters. `source_consensus` therefore requires every declared source
+to be present. A future quorum control would need a separate template and explicit evidence for
+membership, exclusions, and minimum agreeing weight.
+
+## Migration
+
+No data migration runs when V2 is deployed. Existing records without a contract marker are treated
+as V1. V1 APIs continue returning their existing bodies, including legacy left/right evidence.
+
+An operator who wants V2 semantics creates a new V2 rule, validates it in parallel, then disables or
+deletes the old rule according to their operational process. Historical V1 captures, alerts, and
+accepted evidence snapshots remain attached to the V1 rule and are never rewritten.

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -1,18 +1,23 @@
 # Technical Documentation
 
-Engineering reference for the V1 reconciliation work. Start with the architecture doc if you're new to the project; use the topical docs as reference once you have the shape.
+Engineering reference for the reconciliation service. The unprefixed V1 API remains the compatibility
+surface for existing rules; the `/v2` API adds aggregate multi-source equations and exchange-rate
+bounds. Start with the architecture doc if you're new to the project; use the topical docs as reference
+once you have the shape.
 
 ## Documents
 
 | Document | What it covers |
 |---|---|
 | [architecture.md](./architecture.md) | How the CEL kernel, templates, the ledger-native store (`_recon`), and the service layer fit together — plus the account model + transition workflow. |
-| [api.md](./api.md) | The V1 `/rules` / `/alerts` API + the events sink (evaluations are non-durable). |
-| [workflows.md](./workflows.md) | Lifecycle flows: rule create → evaluate (live reads + capture) → alert → resolve / accept, plus reopen, engine-error, and event delivery. |
-| [templates.md](./templates.md) | The V1 GA template catalog — spec shapes, validation rules, what each compiles to, evidence format. |
+| [ledger-v3-storage.md](./ledger-v3-storage.md) | Exact Ledger v3 account types, assets, Numscript programs, indexes, queries, provisioning, and timeline persistence. |
+| [api.md](./api.md) | V1/V2 API coexistence, route isolation, rule/evaluation/alert contracts, and the events sink. |
+| [workflows.md](./workflows.md) | Lifecycle flows: versioned rule create → live evaluation + capture → alert → resolve / accept, plus reopen, engine-error, and event delivery. |
+| [templates.md](./templates.md) | V1 templates and V2 multi-source controls — spec shapes, exact arithmetic, validation, fingerprints, and evidence. |
 | [alert-period-model.md](./alert-period-model.md) | Why alerts are scoped by reconciliation period (cadence), and how it's implemented. |
 | [scheduler.md](./scheduler.md) | The in-process cron scheduler — how rules fire automatically, and the single-instance caveat. |
 | [notification-suppression.md](./notification-suppression.md) | Why a still-broken alert shouldn't re-page on every tick — and why suppression now lives at the consumer. |
+| [ADR-004](../prd/adr-004-multi-source-comparisons.md) | Why V2 is additive, how equations and exchange rates are defined, and why arithmetic never uses floating point. |
 
 ## Status legend used throughout
 

--- a/docs/technical/api.md
+++ b/docs/technical/api.md
@@ -1,14 +1,189 @@
 # API Reference
 
-Reconciliation exposes one API surface:
+Reconciliation exposes two isolated API surfaces:
 
 - **V1 Ledger Clarity** (`/rules` / `/alerts`) — EE-gated at V1 GA.
+- **V2 multi-source controls** (`/v2/rules` / `/v2/alerts`) — additive; V1 bodies are unchanged.
 
 It uses the auth scopes (`reconciliation:read`, `reconciliation:write`) and the `ErrorResponse` shape described below.
 
 > Status: the V1 endpoints are ✅ shipped; alert-transition events are delivered via the ledger's
-> native events sink (see [Events](#events) below). Evaluations are **non-durable** — there is no
-> evaluations read surface. OpenAPI lives in [openapi.yaml](../../openapi.yaml).
+> native events sink (see [Events](#events) below). Evaluations have no standalone evaluation
+> resource, but their immutable captures are available from each rule's `/captures` endpoint.
+> OpenAPI lives in [openapi.yaml](../../openapi.yaml).
+
+---
+
+<a id="v1v2-coexistence"></a>
+## V1/V2 coexistence
+
+The route selects the contract. Clients do not send `contractVersion` on create or patch:
+
+| Contract | Rule routes | Alert routes |
+|---|---|---|
+| V1 | `/rules`, `/rules/{id}`, `/rules/{id}/evaluate`, `/rules/{id}/captures`, `/rules/{id}/timeline` | `/alerts`, `/alerts/{id}`, `/events`, `/ack`, `/resolve`, `/accept`, `/snooze`, `/unsnooze` |
+| V2 | `/v2/rules`, `/v2/rules/{id}`, `/v2/rules/{id}/evaluate`, `/v2/rules/{id}/captures`, `/v2/rules/{id}/timeline` | `/v2/alerts`, `/v2/alerts/{id}`, `/ack`, `/resolve`, `/accept`, `/snooze`, `/unsnooze` |
+
+`contractVersion` is persisted immutably on rules, alerts, and captures. Missing markers on legacy
+records decode as version 1; new V1 writes store 1 and V2 writes store 2. V1 response bodies remain
+byte-shape compatible and do not gain the field. V2 rule, alert, and capture responses expose the
+required read-only value `"contractVersion": 2`.
+
+Version isolation is enforced before pagination and lookup results are returned. V1 lists never
+contain V2 resources and V2 lists never contain V1 resources. Fetching, patching, deleting,
+evaluating, listing captures for, or acting on an ID through the wrong version returns `404`; it does
+not disclose that the resource exists in another contract. A patch cannot change contract version.
+
+The legacy V1 per-alert `/events` endpoint remains a deferred compatibility surface. V2 does not
+duplicate that empty endpoint; V2 alert lifecycle items are available through the backed,
+rule-scoped `/v2/rules/{id}/timeline` journal.
+
+V1 `source_parity` remains binary and keeps `templateSpec.left` / `.right` plus its four legacy
+evidence keys. V2 uses named `sources[]` and does not accept V1 template kinds. There is no automatic
+rewrite of rules, captures, alerts, or accepted evidence snapshots. See
+[ADR-004](../prd/adr-004-multi-source-comparisons.md).
+
+V1 validation messages present those inputs as **Source A** and **Source B**, while retaining the
+stable machine path separately—for example, `Source A is missing an asset (field: left.asset)`.
+This is a presentation-only change: request fields, stored specifications, and evidence keys remain
+unchanged.
+
+---
+
+## V2 multi-source controls
+
+The lifecycle, cadence, severity, scheduling, pagination, alert actions, and auth scopes match V1;
+only the versioned route, typed template catalog, and evidence contracts differ.
+
+### Create a balance equation
+
+`POST /v2/rules`
+
+```json
+{
+  "name": "cash-plus-receivable-equals-obligation",
+  "templateKind": "balance_equation",
+  "templateSpec": {
+    "sources": [
+      { "id": "cash", "ledger": "main", "query": { "$match": { "address": "cash:*" } }, "asset": "USD/2" },
+      { "id": "receivable", "ledger": "main", "query": { "$match": { "address": "receivable:*" } }, "asset": "USD/2" },
+      { "id": "obligation", "ledger": "control", "query": { "$match": { "address": "liability:*" } }, "asset": "USD/2" }
+    ],
+    "terms": [
+      { "source": "cash", "coefficient": 1 },
+      { "source": "receivable", "coefficient": 1 },
+      { "source": "obligation", "coefficient": -1 }
+    ],
+    "tolerance": "0"
+  },
+  "severity": "high",
+  "cadence": "daily"
+}
+```
+
+The `201` rule contains `contractVersion: 2` and its exact `compiledCEL`. Evaluation evidence uses
+`schemaVersion: 2`, `operation: "balance_equation"`, named source values/contributions, residual,
+absolute residual, tolerance, and `compiledCEL`.
+
+### Create exchange-rate bounds
+
+`POST /v2/rules`
+
+```json
+{
+  "name": "eur-usd-valuation-band",
+  "templateKind": "exchange_rate_bounds",
+  "templateSpec": {
+    "sources": [
+      { "id": "eur", "ledger": "treasury", "query": { "$match": { "address": "position:eur" } }, "asset": "EUR/2" },
+      { "id": "usd", "ledger": "treasury", "query": { "$match": { "address": "valuation:usd" } }, "asset": "USD/2" }
+    ],
+    "baseSource": "eur",
+    "quoteSource": "usd",
+    "rate": { "target": "1.10", "toleranceBps": 25 }
+  }
+}
+```
+
+The observed rate means quote major units per base major unit. Bounds are inclusive and evaluated by
+exact CEL financial built-ins backed by `big.Int` / `big.Rat`; JSON decimal strings are never
+converted to binary floating point. A zero base produces a normal failed outcome with
+`undefinedReason: "base_balance_zero"`.
+
+### Create source consensus
+
+`POST /v2/rules`
+
+```json
+{
+  "name": "usd-record-consensus",
+  "templateKind": "source_consensus",
+  "templateSpec": {
+    "sources": [
+      { "id": "subledger", "ledger": "main", "query": { "$match": { "address": "customers:total" } }, "asset": "USD/2" },
+      { "id": "processor", "kind": "account_metadata", "ledger": "processor", "query": { "$match": { "address": "reported:balance" } }, "metadataKey": "reported_balance", "asset": "USD/2" },
+      { "id": "bank", "kind": "account_metadata", "ledger": "bank", "query": { "$match": { "address": "statement:closing" } }, "metadataKey": "closing_balance", "asset": "USD/2" }
+    ],
+    "tolerance": "100"
+  }
+}
+```
+
+Consensus passes only when every declared source is present and the widest balance spread is within
+tolerance. Evidence names the minimum and maximum sources and lists missing source IDs.
+
+### Create portfolio coverage bounds
+
+`POST /v2/rules`
+
+```json
+{
+  "name": "liquid-reserve-coverage",
+  "templateKind": "coverage_ratio_bounds",
+  "templateSpec": {
+    "sources": [
+      { "id": "cash", "ledger": "treasury", "query": { "$match": { "address": "assets:cash:*" } }, "asset": "USD/2" },
+      { "id": "securities", "ledger": "treasury", "query": { "$match": { "address": "assets:securities:*" } }, "asset": "USD/2" },
+      { "id": "liabilities", "ledger": "main", "query": { "$match": { "address": "liabilities:customers:*" } }, "asset": "USD/2" }
+    ],
+    "numeratorTerms": [
+      { "source": "cash", "coefficient": 1 },
+      { "source": "securities", "coefficient": 1 }
+    ],
+    "denominatorTerms": [
+      { "source": "liabilities", "coefficient": 1 }
+    ],
+    "ratio": { "min": "1.00", "max": "1.20" }
+  }
+}
+```
+
+Every source is assigned exactly once to a signed portfolio. Evidence preserves both totals, every
+contribution, and the exact reduced ratio. A zero denominator is a typed failed outcome.
+
+### V2 validation errors
+
+Invalid specs return the existing `400 VALIDATION` envelope. Human wording uses the source label or
+ID and retains a machine path in the detail:
+
+```json
+{
+  "errorCode": "VALIDATION",
+  "errorMessage": "templates: invalid spec",
+  "details": "Source \"obligation\" is missing an asset (field: sources[2].asset)"
+}
+```
+
+All source queries are validated before persistence. One invalid/unindexed query rejects the entire
+rule; transient ledger failures remain server errors rather than being misclassified as validation.
+
+See [templates.md](./templates.md#v2-catalog) for the complete specs, arithmetic,
+fingerprints, and evidence.
+
+`GET /v2/rules/{id}/captures` returns the same cursor envelope as V1, with
+`contractVersion: 2` on each capture and the V2 evidence object preserved unchanged. V2 alert
+evidence and `resolution.evidenceSnapshot` preserve that same object; they are never translated to
+V1 left/right keys.
 
 ---
 
@@ -90,11 +265,10 @@ the template's `tolerance`. Returns `200` + the evaluation result (not persisted
 }
 ```
 
-`evidence` records every failing fingerprint plus a passing fingerprint only when that pass
-automatically resolves an active alert. This bounded roster documents both the break and its later
-successful reconciliation without persisting thousands of unrelated passing fingerprints from a
-wide rule. An all-`PASS` evaluation with no active alert still has `"evidence": []`. The evaluation
-object itself is **not** a durable entity (a deterministic projection, RFC §4.4.2) — but each run's
+`evidence` records every passing and failing fingerprint and the exact values used for its verdict.
+This complete roster documents both breaks and successful reconciliations, including passes that do
+not mutate an alert. The evaluation object itself is **not** a durable entity (a deterministic
+projection, RFC §4.4.2) — but each run's
 **capture** is (ADR-003), queryable via `GET /rules/{id}/captures` below.
 
 #### `GET /rules/{id}/captures` — evaluation history (captures)
@@ -121,7 +295,16 @@ queryable **live** today — no event sink required. Cursor-paginated, most-rece
         "verdict":       "fail",
         "trigger":       "scheduled",
         "capturedAt":    "2026-03-01T00:00:00Z",
-        "evidence":      { "delta": "5" }
+        "evidence": {
+          "asset": "USD/2",
+          "leftSource": "ledger:main",
+          "leftBalance": "100",
+          "rightSource": "ledger:control",
+          "rightBalance": "95",
+          "difference": "5",
+          "signedDiff": "5",
+          "tolerance": 0
+        }
       }
     ]
   }
@@ -225,18 +408,46 @@ Clears an active snooze before its window elapses. Idempotent — unsnoozing an 
 <a id="events"></a>
 ## Events
 
+### Rule timeline
+
+`GET /rules/{ruleID}/timeline` and `GET /v2/rules/{ruleID}/timeline` return one
+newest-first, cursor-paginated history containing rule revisions, evaluation
+observations, and alert lifecycle activity. Every item uses a common envelope:
+
+```json
+{
+  "id": "8941:0",
+  "sequence": "8941",
+  "kind": "evaluation.completed",
+  "category": "evaluation",
+  "ruleID": "…",
+  "contractVersion": 2,
+  "ruleRevision": "sha256:…",
+  "correlationID": "evaluation UUID",
+  "occurredAt": "2026-07-18T10:30:00Z",
+  "recordedAt": "2026-07-18T10:30:00.042Z",
+  "payload": {}
+}
+```
+
+Read the current rule with `GET /rules/{id}` (or `/v2/rules/{id}`) and page the
+timeline independently below it. `revision` on the current rule and
+`ruleRevision` on an evaluation identify the exact effective configuration.
+The journal is forward-only: pre-rollout state is not presented as invented
+lifecycle activity.
+
 Reconciliation runs **no message bus of its own**. Every alert transition writes a self-describing
 `last_transition` envelope into the `alert:item` metadata in the same atomic batch as the state
 change, so the control-ledger's log entry for that write carries "what happened":
-`COMMITTED_TRANSACTION` for lifecycle moves (open/ack/resolve/accept/auto-resolve),
-`SAVED_METADATA`/`DELETED_METADATA` for snooze/unsnooze.
+`COMMITTED_TRANSACTION` for lifecycle moves and status-neutral snooze/unsnooze interactions.
 
 Delivery is the **ledger's native events sink**. When the operator sets `--events-sink-url`,
 reconciliation provisions an HTTP webhook sink at boot (name `reconciliation`, event types
 `[COMMITTED_TRANSACTION, SAVED_METADATA, DELETED_METADATA]`, optional `--events-sink-secret` for the
 `X-Webhook-Signature` HMAC). The ledger delivers each matching committed log entry to the endpoint
-(e.g. the Webhooks module). Sink filtering is by event *type*, not ledger, so consumers filter on
-`event.ledger == _recon`.
+(e.g. the Webhooks module). The metadata types remain subscribed for compatibility with older or
+direct metadata writers. Sink filtering is by event *type*, not ledger, so consumers filter on the
+configured control-ledger name (default `reconciliation`).
 
 | Transition (`type`) | Fires when |
 |---|---|
@@ -271,6 +482,9 @@ event per committed write; repeat-suppression and snooze *muting* are a **consum
 Webhooks module / a future digest), driven by the `occurred` bumps and the `snooze` metadata (see
 [notification-suppression.md](./notification-suppression.md)). This is a deliberate deferral (RFC §4.4);
 the write-side `notify` flag and the watermill publisher were removed with Postgres.
+
+The events sink remains delivery infrastructure. Product history reads use the
+rule-scoped activity account and do not scan the global Ledger log.
 
 ---
 

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -2,12 +2,14 @@
 
 Where the pieces live and how they fit together, **after the ledger-native migration**.
 Reconciliation is now **Postgres-free and stateless**: all its state lives on a Ledger v3
-control-ledger (`_recon`), it reads the ledgers it reconciles **live**, and it records each
-evaluation as an immutable `_recon` **capture** transaction. For the *why* behind the kernel, see
+control ledger (default name `reconciliation`; `_recon` in design shorthand), it reads the ledgers
+it reconciles **live**, and it records each evaluation as an immutable **capture** transaction. For
+the *why* behind the kernel, see
 [ADR-001](../prd/adr-001-cel-kernel.md); for the read/consistency model,
 [ADR-003](../prd/adr-003-checkpoint-anchor-and-crosscheck.md) (which supersedes the checkpoint model
 of [ADR-002](../prd/adr-002-pit-consistency.md)); for the storage/event design, the
-[ledger-native storage RFC](../drafts/rfc-ledger-native-storage.md).
+[ledger-native storage RFC](../drafts/rfc-ledger-native-storage.md); and for V2 multi-source
+semantics, [ADR-004](../prd/adr-004-multi-source-comparisons.md).
 
 ---
 
@@ -15,10 +17,10 @@ of [ADR-002](../prd/adr-002-pit-consistency.md)); for the storage/event design, 
 
 ```text
 internal/
-├── models/          Go types — Rule, Evaluation, Alert, AlertEvent, Resolution
+├── models/          Go types — Rule, Evaluation, Alert, AlertEvent, Resolution, RuleActivity
 ├── store/           Storage-agnostic contract types + sentinels (leaf; no ORM) — the
 │                    Store interface shape shared by the service and ledgerstore
-├── ledgerpb/        Generated Ledger v3 gRPC protos (synced from ledger-connect)
+├── ledgerpb/        Generated Ledger v3 gRPC protos (synced from Ledger release/v3.0)
 ├── ledger/          Ledger v3 gRPC client: transactions, metadata, account/log queries,
 │                    events sinks; live Reader; provisioner
 ├── ledgerauth/      Ed25519 request signing + TLS; refuses insecure transport by default (F2)
@@ -28,7 +30,7 @@ internal/
 ├── ledgerresolver/  Adapter: ledger.Reader (live) → engine.LedgerResolver
 ├── engine/          Internal CEL kernel
 │   └── types.go / source.go / resolvers.go / builtins.go / engine.go / budget.go / errors.go
-├── templates/       V1 GA template catalog (source.go, ledger_invariant, account_threshold, source_parity)
+├── templates/       Versioned template catalogs: V1 binary controls + V2 named-source controls
 └── api/
     ├── service/     Rule / Evaluation / Alert orchestration; live reads + a capture per evaluation
     ├── backend/     Backend interface + generated mock
@@ -52,22 +54,22 @@ flowchart TB
     Svc --> Store[LedgerStore]
     Reg --> Eng[engine.Engine]
     Eng --> LR["Ledger resolver<br/>live Reader adapter"]
-    Store --> Recon[("control-ledger _recon (gRPC)<br/>rules, alerts, captures")]
-    LR --> Data[("data-ledgers A/B<br/>(live)")]
+    Store --> Recon[("control ledger (gRPC)<br/>rules, alerts, captures, activity")]
+    LR --> Data[("data ledgers A/B/C/...<br/>(live)")]
 ```
 
 | Layer | Responsibility | Key types |
 |---|---|---|
 | **HTTP** | OpenAPI-typed surface; auth scopes; cursor pagination | handlers in [`internal/api/`](../../internal/api/), routes in [`router.go`](../../internal/api/router.go) |
 | **Service** | Validation, evaluation orchestration, **capture recording**, alert dedup + lifecycle | `Service` (rule.go / evaluation.go / alert.go) |
-| **Templates** | Typed specs → direct `big.Int` math; per-fingerprint outcomes; rendered CEL for explainability | `Evaluator`, `Outcome`, `Registry` |
-| **Engine** | CEL type-check at rule-create + budget/resolver dispatch (live reads) | `Engine`, `Source`, `Resolvers`, `Limits` |
+| **Templates** | Versioned typed specs; per-fingerprint outcomes; V1 integer and V2 exact integer/rational semantics | `Evaluator`, `Outcome`, versioned registries |
+| **Engine** | CEL type-check plus exact financial built-ins backed by `big.Int` / `big.Rat`; budget/resolver dispatch | `Engine`, `Source`, `Resolvers`, `Limits` |
 | **Resolvers** | Ledger reads **live** (strictly ledger↔ledger) | `ledgerresolver.Resolver` (over `ledger.Reader`) |
-| **Storage** | Rules + alert lifecycle + immutable evaluation **captures** as Numscript batches + typed metadata on `_recon` | `LedgerStore`, `ledger.Client`, `ledgerschema` |
+| **Storage** | Rules + alert lifecycle + immutable evaluation **captures** and combined activity history as Numscript batches + typed metadata on the control ledger | `LedgerStore`, `ledger.Client`, `ledgerschema` |
 
 ---
 
-## The kernel — CEL for validation + explainability
+## The kernel — typed financial evaluation
 
 A `Source` is an opaque CEL value naming a backend dataset (`ledgerSet(ledger, query)`)
 over builtins (`balance`, `balances`, `sum`, `abs`). At **rule-create** time the engine
@@ -77,10 +79,26 @@ equivalent CEL into `evidence.compiledCEL` for explainability but do **not** run
 `TestCrossCheck_*` guards that the two agree). `engine.Evaluate` (the CEL runtime) is reserved for
 the post-GA raw-CEL power mode.
 
+V2 retains `compiledCEL`, but introduces purpose-built financial built-ins whose implementations use
+exact `big.Int` / `big.Rat` arithmetic. The typed template evaluator's direct math is authoritative;
+the equivalent built-ins keep compiled CEL exact for explainability and cross-checking.
+`balance_equation` evaluates a signed integer-coefficient sum; `source_consensus` evaluates the
+symmetric max-minus-min spread; `exchange_rate_bounds` compares a quote/base ratio after accounting
+for both asset precisions; and `coverage_ratio_bounds` compares two signed portfolio totals. The
+ratio operations use exact rational arithmetic. No V2 path converts ledger values or decimal bounds
+to binary floating point.
+
 Resolvers (ADR-003): reconciliation is strictly **ledger↔ledger**.
 - **Ledger sources** read **live** — a single `AggregateVolumes` is an internally consistent
   snapshot; cross-ledger skew is absorbed by the template's `tolerance`. Backed by
   `ledgerresolver.Resolver` over `ledger.Reader`.
+
+Ledger v3 segregates balances by `(account, asset, color)`. Current reconciliation source
+contracts remain asset-based: aggregate reads request `collapse_colors`, account reads sum all
+returned color rows for the same asset, and control-ledger point reads request collapsed rows.
+Consequently, an observed `USD/2` balance is the total of its uncolored and colored buckets. The
+vendored protobuf contract preserves `color`, but selecting or comparing an individual color is
+not exposed by V1 or V2 templates; that would require an explicit, versioned source selector.
 
 ```mermaid
 flowchart LR
@@ -92,14 +110,29 @@ flowchart LR
 See [engine/engine.go](../../internal/engine/engine.go), [engine/builtins.go](../../internal/engine/builtins.go),
 and the adapter [ledgerresolver/resolver.go](../../internal/ledgerresolver/resolver.go).
 
+## Contract-version isolation
+
+V1 and V2 share lifecycle machinery and the control-ledger, but not resource visibility. Rules,
+alerts, and captures persist an immutable integer `contract_version`. A missing marker on a legacy
+record means V1. The unprefixed handlers scope every operation to version 1; `/v2` handlers scope to
+version 2. Lists apply the version predicate before cursor construction, avoiding both data leakage
+and pagination holes. Point lookups and mutations through the wrong route return not found.
+
+The version boundary also selects the template registry: V1 accepts the existing catalog and wire
+shapes; V2 accepts `balance_equation`, `exchange_rate_bounds`, `source_consensus`, and
+`coverage_ratio_bounds`. A patch cannot move a rule between contracts. Both versions then feed the
+same capture and alert orchestration, carrying their native evidence shape unchanged.
+
 ---
 
 ## The control-ledger data model
 
-Reconciliation stores everything on `_recon` — there is no relational schema. The chart has
-**6 account types** plus three precision-0 assets — `ALERT` (the lifecycle marker), `OCC`
-(occurrence counter), and `CAPTURE` (per-evaluation counter). The data-ledgers being reconciled
-(A, B) are *external* and read-only to recon; they are not part of this chart.
+Reconciliation stores everything on its control ledger — there is no relational schema. The chart
+has **8 account types** plus four precision-0 assets: `ALERT` (the lifecycle marker), `OCC`
+(occurrence counter), `CAPTURE` (per-evaluation counter), and `ACTIVITY` (combined-history
+counter). The data ledgers being reconciled (A, B, C, and beyond) are *external* and read-only to
+recon; they are not part of this chart. The complete executable mapping is documented in
+[ledger-v3-storage.md](./ledger-v3-storage.md).
 
 | Account | Type | Role |
 |---|---|---|
@@ -109,15 +142,19 @@ Reconciliation stores everything on `_recon` — there is no relational schema. 
 | `alert:pool:rule:{id}` | NORMAL | mint source for `ALERT`+`OCC` (overdraft) and free gauges |
 | `capture:rule:{id}:per:{p}` | NORMAL | **evaluation capture bucket** (ADR-003) — one immutable capture tx per evaluation (snapshot in tx metadata); `−balance(·, CAPTURE)` = count |
 | `capture:pool:rule:{id}` | NORMAL | mint source for `CAPTURE` (overdraft) |
+| `activity:rule:{id}` | NORMAL | append-only transaction stream for the combined rule timeline |
+| `activity:pool:rule:{id}` | NORMAL | mint source for `ACTIVITY` (overdraft) |
 
 The **marker is the status source-of-truth**; the `status` metadata key is an LWW mirror for O(1)
 point-reads. Both are written in **one atomic Numscript batch**, so they never diverge.
 
 ### Transition workflow
 
-Five numscripts (library, pinned `v1.0.0`): `alert_open` (mint marker + OCC), `alert_bump`
+Six numscripts (library, pinned `v2.0.0`): `alert_open` (mint marker + OCC), `alert_bump`
 (OCC only), `alert_move` (guarded marker move, no OCC), `alert_reopen` (guarded move + OCC),
-and `capture` (mint 1 `CAPTURE` → capture bucket).
+`capture` (mint 1 `CAPTURE` → capture bucket), and `activity` (append a rule-scoped history item).
+Every program also posts one `ACTIVITY` unit; rule changes and status-neutral alert interactions use
+the generic `activity` program.
 
 ```mermaid
 flowchart TB
@@ -139,7 +176,8 @@ flowchart TB
   **EPHEMERAL purges it** → a closed alert has *no* marker (no accumulation). Reopen re-mints.
 - **Free gauges.** `−balance(pool, ALERT)` = active (open+ack) alerts; `−balance(pool, OCC)` =
   total occurrences.
-- **Snooze / unsnooze** are metadata-only (no marker move), status-neutral.
+- **Snooze / unsnooze** are status-neutral and do not move the marker. Their account metadata
+  mutation and activity record now commit atomically in an `activity` transaction.
 - **Idempotency.** Each batch carries a deterministic key over `(action, rule, fingerprint,
   period, evaluationID)` — a gRPC retransmit is deduplicated by the ledger (see **F17** in the
   migration log for the content-sensitive caveat).
@@ -162,11 +200,24 @@ freshness floor) is available but unused.
 
 Every evaluation is recorded as an **immutable capture transaction** on `_recon` (ADR-003): a
 self-describing snapshot (`verdict`, `trigger`, `evidence`, …) on a `COMMITTED_TRANSACTION`, plus a
-`CAPTURE` counter unit in the `capture:rule:{id}:per:{p}` bucket. Evidence is bounded to every failing
-outcome plus passing outcomes that automatically resolve an active alert; unrelated passes are not
-retained. This is the durable "what reconciled and when" — including the exact observed values that
+`CAPTURE` counter unit in the `capture:rule:{id}:per:{p}` bucket. Evidence retains every outcome,
+including successful outcomes that do not mutate an alert. This is the durable "what reconciled and
+when" — including the exact observed values that
 cleared a prior break — receipt-signed and append-only, replacing a queryable evaluation table
 (RFC §4.4.2). The run result is also returned from `EvaluateRule`.
+
+Every externally meaningful mutation also posts one precision-zero `ACTIVITY`
+unit to `activity:rule:{ruleID}`. Rule metadata changes use a generic activity
+transaction; captures and alert transitions include the posting in their
+existing transaction. State and history therefore commit atomically. Transaction
+metadata carries a versioned semantic envelope, while Rule and Alert accounts
+remain current-state projections; this is not full event sourcing.
+
+For V2, N sources are still separate live reads. A multi-source equation therefore widens the
+possible read-skew window; its minor-unit tolerance must reflect acceptable ingestion skew. An FX
+bound must likewise be wide enough for the operational clocks of its base and quote records. The
+capture freezes every source value, contribution or exact ratio component used by the verdict so
+the decision remains reproducible after the ledgers move on.
 
 ---
 
@@ -175,14 +226,16 @@ cleared a prior break — receipt-signed and append-only, replacing a queryable 
 Reconciliation runs **no message bus**. On every transition the store stamps a self-describing
 `last_transition` envelope (`reconciliation.alert.<type>`, subject, prev/new status,
 correlationID, payload) into `alert:item` metadata, so each Ledger log entry for that write is
-self-describing — `COMMITTED_TRANSACTION` for lifecycle moves, `SAVED_METADATA`/`DELETED_METADATA`
-for snooze/unsnooze.
+self-describing. Current lifecycle moves and snooze/unsnooze interactions are all
+`COMMITTED_TRANSACTION` events because each write appends activity in a transaction.
 
 Delivery is the ledger's native **events sink**: when `--events-sink-url` is configured, recon
 provisions an HTTP webhook sink at boot for `[COMMITTED_TRANSACTION, SAVED_METADATA,
-DELETED_METADATA]`. The ledger delivers matching events to the webhook (e.g. the Webhooks
-module); consumers filter on `event.ledger == _recon` (sink filtering is by event type, not
-ledger — RFC §4.4). See [ledger/events_sink.go](../../internal/ledger/events_sink.go).
+DELETED_METADATA]`. The metadata event types remain subscribed for compatibility with older or
+direct metadata writers; current lifecycle activity is transaction-backed. The ledger delivers
+matching events to the webhook (e.g. the Webhooks module); consumers filter on the configured
+control-ledger name (sink filtering is by event type, not ledger — RFC §4.4). See
+[ledger/events_sink.go](../../internal/ledger/events_sink.go).
 
 ---
 
@@ -199,6 +252,8 @@ ledger — RFC §4.4). See [ledger/events_sink.go](../../internal/ledger/events_
 - **Statelessness** — recon holds no local state; multiple replicas share `_recon`. Reads are
   live and each write (alert transition, capture) is idempotent per (rule, period, evaluation), so
   concurrent replicas converge without coordination.
+- **Rule configuration identity** is a content-derived SHA-256 revision. Captures
+  retain it so an observation stays tied to the configuration evaluated.
 
 ---
 
@@ -218,8 +273,9 @@ strictly ledger↔ledger and reads the data ledgers directly over gRPC.
 
 ## What's not here yet
 
-- **`ListAlertEvents` (paginated history)** — returns empty; a queryable history needs a
-  downstream sink (ClickHouse/Databricks), since the ledger log has no per-account filter (RFC §10).
+- **Legacy history backfill** — the activity journal is complete only from its
+  rollout. A future offline import may scan Ledger logs, but request handlers do
+  not scan the global log.
 - **Semantic event types + replay API** — the future generic event-log; today's events are
   generic log-derived events carrying the `last_transition` envelope.
 - **Certifiable atomic multi-ledger read** for exact replay / provable simultaneity — a future

--- a/docs/technical/ledger-v3-storage.md
+++ b/docs/technical/ledger-v3-storage.md
@@ -148,8 +148,9 @@ multi-source specifications and is isolated by route and persisted contract vers
 
 Storage changes should exercise:
 
-- schema, query-filter, Numscript, provisioner, and LedgerStore unit tests;
-- the serial `it`-tagged suite against Ledger v3;
+- schema, query-filter, Numscript, provisioner, and LedgerStore unit tests with `just tests`;
+- the serial `it`-tagged suite against a live Ledger v3 on `localhost:8888` with
+  `just tests-integration`;
 - a live create, evaluate, alert action, timeline read, and delete flow;
 - restart provisioning against the same control ledger to verify additive idempotency and index
   readiness behavior.

--- a/docs/technical/ledger-v3-storage.md
+++ b/docs/technical/ledger-v3-storage.md
@@ -1,0 +1,155 @@
+# Ledger v3 storage model
+
+This document is the consolidated map of how Reconciliation uses Ledger v3. It describes the
+current implementation, not an aspirational event-sourcing model.
+
+Reconciliation is stateless and Postgres-free. It uses:
+
+- one **control ledger** for its own rules, alerts, captures, and activity history; the default
+  ledger name is `reconciliation` and can be changed with `--ledger-control-name`;
+- one or more **data ledgers**, which are read live and never mutated by Reconciliation.
+
+The `_recon` name used in older design documents is a conceptual shorthand for the control ledger,
+not its configured default name.
+
+```mermaid
+flowchart LR
+    API["HTTP API and service"] --> Store["LedgerStore"]
+    Store --> Control["control ledger (default: reconciliation)"]
+    API --> Templates["versioned templates"]
+    Templates --> Resolver["live Ledger resolver"]
+    Resolver --> Data["data ledgers A, B, C, ..."]
+```
+
+## Executable sources of truth
+
+The persisted model is defined by code. When this document and code disagree, these files are
+authoritative:
+
+| Concern | Definition |
+|---|---|
+| Ledger name, assets, and account address builders | [`internal/ledgerschema/addresses.go`](../../internal/ledgerschema/addresses.go) |
+| Account types, typed metadata, indexes, and prepared queries | [`internal/ledgerschema/schema.go`](../../internal/ledgerschema/schema.go) |
+| Stored Numscript programs and their pinned version | [`internal/ledgerschema/scripts.go`](../../internal/ledgerschema/scripts.go) |
+| Query-filter construction and JSON-query translation | [`internal/ledgerschema/filters.go`](../../internal/ledgerschema/filters.go), [`internal/ledgerschema/query.go`](../../internal/ledgerschema/query.go), and [`internal/ledgerstore/filter.go`](../../internal/ledgerstore/filter.go) |
+| Idempotent startup provisioning | [`internal/ledger/provisioner.go`](../../internal/ledger/provisioner.go) |
+| Runtime wiring and enforcement mode | [`cmd/ledger.go`](../../cmd/ledger.go) |
+| Persisted/read model mappings | [`internal/ledgerstore/`](../../internal/ledgerstore/) |
+
+## Control-ledger chart
+
+The chart contains eight account types. Pool accounts are declared overdraft sources used to mint
+precision-zero markers and counters; they do not represent customer money.
+
+| Address pattern | Persistence | Purpose |
+|---|---|---|
+| `rule:{ruleId}` | NORMAL | Current rule configuration as typed account metadata. |
+| `alert:item:rule:{ruleId}:per:{period}:fp:{fpHash}` | NORMAL | Canonical alert record, occurrence count, and current-state metadata. |
+| `alert:st:{open|ack}:rule:{ruleId}:per:{period}:fp:{fpHash}` | EPHEMERAL | The single `ALERT` lifecycle marker. It is drained and purged when the alert closes. |
+| `alert:pool:rule:{ruleId}` | NORMAL | Per-rule overdraft source for `ALERT` and `OCC`. |
+| `capture:rule:{ruleId}:per:{period}` | NORMAL | Address touched by every immutable evaluation-capture transaction. |
+| `capture:pool:rule:{ruleId}` | NORMAL | Per-rule overdraft source for `CAPTURE`. |
+| `activity:rule:{ruleId}` | NORMAL | Ordered transaction stream for the combined rule timeline. |
+| `activity:pool:rule:{ruleId}` | NORMAL | Per-rule overdraft source for `ACTIVITY`. |
+
+The four assets all have precision zero:
+
+| Asset | Meaning |
+|---|---|
+| `ALERT` | Exactly one marker for each active alert. |
+| `OCC` | One unit for each alert occurrence. |
+| `CAPTURE` | One unit for each recorded evaluation. |
+| `ACTIVITY` | One unit for each rule lifecycle, evaluation, or alert activity item. |
+
+## Current state and immutable history
+
+Rule and alert accounts are current-state projections. Typed account metadata supports direct reads
+and filtering: rule fields include the template specification, contract version, revision, cadence,
+schedule, and labels; alert fields include status, evidence, acknowledgement, resolution, snooze,
+and the latest transition envelope.
+
+Immutable history lives on transactions:
+
+- a capture transaction stores the evaluation envelope, including verdict, trigger, evidence,
+  contract version, rule revision, timings, result, and error;
+- an activity transaction stores a versioned semantic envelope containing kind, rule, occurrence
+  time, contract version, revision, correlation identifier, and payload;
+- alert and capture programs post `ACTIVITY` in the same transaction as their state mutation;
+- rule create, update, delete, snooze, and unsnooze use the generic activity program and apply
+  account metadata atomically in that transaction.
+
+The combined timeline therefore records rule lifecycle, evaluation/capture activity, alert
+lifecycle, and manual alert interactions in one per-rule stream. It is complete from the activity
+journal rollout onward. The API does not fabricate pre-rollout activity from current state.
+
+Capture evidence retains every outcome, including successful outcomes that do not mutate an alert.
+Each timeline evaluation item therefore points to a reproducible observation rather than only
+proving that the run occurred.
+
+## Numscript library and atomicity
+
+The stored library is pinned at `2.0.0` and contains six programs:
+
+| Program | Atomic effect |
+|---|---|
+| `alert_open` | Mint the active marker and first occurrence, then append activity. |
+| `alert_bump` | Increment occurrences, then append activity. |
+| `alert_reopen` | Guarded marker move to open, increment occurrences, then append activity. |
+| `alert_move` | Guarded lifecycle marker move, then append activity. |
+| `capture` | Append a capture counter and activity item. |
+| `activity` | Append an activity item for rule changes or status-neutral alert interactions. |
+
+Lifecycle moves use a bare source account as a compare-and-swap guard. Account metadata and
+transaction metadata are supplied in the same Ledger transaction, so current state and history
+commit together. Deterministic idempotency keys make a retransmitted write safe; callers must not
+reuse a key for different content.
+
+Snooze and unsnooze remain status-neutral and do not move the `ALERT` marker. They are no longer
+metadata-only writes: the activity transaction applies the snooze metadata change and records the
+manual interaction atomically.
+
+## Queries and indexes
+
+Typed metadata declarations and query indexes are separate concerns. Every account field used by
+the list-filter translator has an explicit account-metadata index. Dynamic `label.*` keys are not
+indexed.
+
+The transaction address index is required by both capture history and the rule timeline. Without
+it, Ledger rejects address-filtered transaction queries with `FailedPrecondition` and an
+`index not found: address` detail. Index creation is asynchronous; immediately after provisioning,
+reads can temporarily return `Unavailable` with `index is still building` even though the index is
+already declared.
+
+Only two fixed hot paths are prepared queries:
+
+- `alerts-open-count` aggregates open alert markers;
+- `rules-enabled` lists rules used by the scheduler.
+
+Rule and alert filters, capture history, and activity history use structured `QueryFilter` values
+built at runtime. Multi-source data reads use the data-ledger aggregation/account APIs and are
+separate from these control-ledger queries.
+
+## Provisioning and schema evolution
+
+The provisioner runs at startup. It creates the control ledger when absent, then reconciles missing
+account types and typed metadata fields, creates indexes and prepared queries, and saves every
+Numscript version. Re-running it is idempotent.
+
+Additive changes are applied to an existing ledger. Destructive changes—removing or retyping a
+field, or changing an account type that already contains accounts—are not silently migrated and
+need an explicit migration plan. The server currently provisions with chart enforcement `AUDIT`;
+the code does not yet enable `STRICT` enforcement.
+
+Contract evolution is independent from the chart. A missing persisted `contract_version` is read
+as V1. V1 keeps `source_parity.left`/`.right` and the legacy evidence keys; V2 stores named
+multi-source specifications and is isolated by route and persisted contract version.
+
+## Verification
+
+Storage changes should exercise:
+
+- schema, query-filter, Numscript, provisioner, and LedgerStore unit tests;
+- the serial `it`-tagged suite against Ledger v3;
+- a live create, evaluate, alert action, timeline read, and delete flow;
+- restart provisioning against the same control ledger to verify additive idempotency and index
+  readiness behavior.

--- a/docs/technical/templates.md
+++ b/docs/technical/templates.md
@@ -1,8 +1,12 @@
-# V1 GA Template Catalog
+# Template Catalog
 
-Templates are the **entire public V1 GA surface** — raw CEL is internal-only (see [ADR-001](../prd/adr-001-cel-kernel.md)). Each template is a typed spec, a validator, an explainer (for the persisted `compiled_cel`), and an end-to-end evaluator that produces one `Outcome` per fingerprint axis (per-asset for V1 GA).
+Templates are the public rule surface — raw CEL is internal-only (see
+[ADR-001](../prd/adr-001-cel-kernel.md)). Each template is a typed spec, a validator, an explainer
+(for the persisted `compiled_cel`), and an end-to-end evaluator that produces one `Outcome` per
+fingerprint axis.
 
-> Status: all three templates are ✅ shipped in [internal/templates/](../../internal/templates/), including `account_threshold` per-account mode.
+> Status: all three V1 templates and four additive V2 templates are ✅ implemented. V2 does not
+> rename or reinterpret any V1 field or evidence key.
 
 ---
 
@@ -12,15 +16,16 @@ Templates are the **entire public V1 GA surface** — raw CEL is internal-only (
 flowchart LR
     Spec[Typed Spec] --> Validate
     Spec --> Explain[Explain → representative CEL]
-    Explain --> Persist[Saved to rule.compiled_cel]
+    Explain --> Compile[Compile / type-check]
+    Compile --> Persist[Saved to rule.compiled_cel]
     Spec --> Evaluate
     Evaluate --> Scout["Scout via resolvers (ledgers, live)"]
     Scout --> Universe["Determine fingerprint axis<br/>(asset universe)"]
     Universe --> Loop[For each axis value]
-    Loop --> RenderCEL[Render per-axis CEL]
-    RenderCEL --> Compile[engine.Compile]
-    Compile --> Run[engine.Evaluate]
-    Run --> Outcome[Outcome: fingerprint + passed + evidence]
+    Loop --> Math[Exact typed arithmetic]
+    Loop --> RenderCEL[Render per-axis compiledCEL]
+    Math --> Outcome[Outcome: fingerprint + passed + evidence]
+    RenderCEL --> Outcome
     Loop --> Outcomes[List of Outcome]
 ```
 
@@ -29,12 +34,18 @@ Every template:
 1. **Validates** the spec at rule-create time. Failures return `ErrInvalidSpec` (→ HTTP 400).
 2. **Explains** itself — produces a representative CEL string for `rule.compiled_cel`. Not executed at runtime.
 3. **Scouts** the asset universe at evaluation time (queries resolvers).
-4. **Evaluates** per asset by rendering a fresh CEL string, compiling it via the kernel, and running it.
+4. **Evaluates** with exact typed arithmetic and renders the equivalent per-outcome `compiledCEL`.
 5. **Returns `[]Outcome`** — one per asset, with fingerprint, pass/fail, and evidence.
 
-A **kernel/template consistency guard** in each template double-checks the kernel's verdict against direct big.Int math and errors loudly on divergence. Catches future kernel drift.
+A golden **kernel/template consistency guard** checks rendered CEL against the authoritative direct
+math, catching future semantic drift without repeating live reads in production evaluation.
 
 Balance reads are centralised in a shared **Source** primitive ([source.go](../../internal/templates/source.go)): a ledger account-set descriptor (`ledger` + `query`) that knows how to resolve to per-asset balances and render its `balance(ledgerSet…)` CEL term. `source_parity` composes sources through it, so there is one code path for "read a balance source".
+
+V2 builds on the same resolver boundary but uses **named aggregate sources**. Every source has a
+stable `id` and one declared `asset`; operations refer to IDs rather than positional left/right
+fields. The V2 shape and arithmetic are fixed by
+[ADR-004](../prd/adr-004-multi-source-comparisons.md).
 
 **Scope.** A ledger source can be read in one of two scopes, a native capability of the Source primitive:
 - **aggregate** (default): the matched account set is summed into one balance per asset. A query matching a single account is the degenerate single-account case — so "single account" and "set of accounts" are both aggregate, differing only in the query.
@@ -217,6 +228,342 @@ abs(balance(ledgerSet("book", "<query json>"), "USD/2") - metadataInt(ledgerSet(
 **The equality primitive** — `source_parity` is the cross-source equality check (`abs(left − right) ≤ tol`), resolving and rendering both sides through the shared `Source` primitive ([source.go](../../internal/templates/source.go)) — one code path for "read a balance source". `account_metadata` is the first non-ledger source kind; an external bank/PSP-account kind slots in the same way once it has a resolver + kernel builtin.
 
 **Code**: [internal/templates/source_parity.go](../../internal/templates/source_parity.go), [internal/templates/source.go](../../internal/templates/source.go)
+
+---
+
+## V2 catalog
+
+V2 templates are available only through the `/v2` API. They are aggregate-only and use the shared
+named-source shape below.
+
+### Named source
+
+```json
+{
+  "id": "book",
+  "label": "Customer balance",
+  "kind": "ledger",
+  "ledger": "main",
+  "query": { "$match": { "address": "accounts:customer:*" } },
+  "asset": "USD/2"
+}
+```
+
+| Field | Rules |
+|---|---|
+| `id` | Required, unique within the rule, `^[A-Za-z][A-Za-z0-9_-]{0,63}$`. This is the stable machine reference. |
+| `label` | Optional operator-facing name. It does not replace `id` in machine references. |
+| `kind` | Optional; defaults to `ledger`. Supported values are `ledger` and `account_metadata`. |
+| `ledger` | Required ledger name. |
+| `query` | Required, non-null query; validated against the ledger before persistence. |
+| `asset` | Required valid asset code. One V2 source produces one declared asset amount. |
+| `metadataKey` | Required only for `account_metadata`; the matched accounts' integer values are summed. |
+
+Each V2 spec accepts at most 32 sources and at least two unless the template is stricter;
+`exchange_rate_bounds` requires exactly two. A ledger source whose declared asset is absent resolves to
+`balance: "0"` and `present: false`. A missing or non-integer metadata value is an evaluation
+`ERROR`, not a silent zero. V2 does not support `per_account` scope.
+
+### 4. `balance_equation`
+
+Asserts that a signed sum of named source balances is within a minor-unit tolerance:
+
+```text
+abs(sum(coefficient_i * balance_i)) <= tolerance
+```
+
+The following rule expresses `receivable + cash = obligation`:
+
+```json
+{
+  "sources": [
+    {
+      "id": "receivable",
+      "label": "Open receivables",
+      "ledger": "main",
+      "query": { "$match": { "address": "receivable:*" } },
+      "asset": "USD/2"
+    },
+    {
+      "id": "cash",
+      "ledger": "main",
+      "query": { "$match": { "address": "cash:settlement" } },
+      "asset": "USD/2"
+    },
+    {
+      "id": "obligation",
+      "ledger": "control",
+      "query": { "$match": { "address": "customer:liability:*" } },
+      "asset": "USD/2"
+    }
+  ],
+  "terms": [
+    { "source": "receivable", "coefficient": 1 },
+    { "source": "cash", "coefficient": 1 },
+    { "source": "obligation", "coefficient": -1 }
+  ],
+  "tolerance": "0"
+}
+```
+
+**Validation**
+
+- Every source is referenced exactly once by `terms`; unknown, duplicate, or unused source IDs are rejected.
+- `coefficient` is a non-zero signed integer.
+- All sources declare the same asset.
+- `tolerance` is a non-negative base-10 integer string of at most 78 digits, in that asset's minor units.
+- Validation details identify the source for people and retain a machine path, for example:
+  `Source "obligation" requires an asset (field: sources[2].asset)`.
+
+**Fingerprint** — `asset:<asset>`
+
+**Evidence**
+
+```json
+{
+  "schemaVersion": 2,
+  "operation": "balance_equation",
+  "asset": "USD/2",
+  "sources": [
+    {
+      "id": "receivable",
+      "label": "Open receivables",
+      "kind": "ledger",
+      "asset": "USD/2",
+      "balance": "7000",
+      "present": true,
+      "coefficient": 1,
+      "contribution": "7000"
+    },
+    {
+      "id": "cash",
+      "kind": "ledger",
+      "asset": "USD/2",
+      "balance": "3000",
+      "present": true,
+      "coefficient": 1,
+      "contribution": "3000"
+    },
+    {
+      "id": "obligation",
+      "kind": "ledger",
+      "asset": "USD/2",
+      "balance": "9950",
+      "present": true,
+      "coefficient": -1,
+      "contribution": "-9950"
+    }
+  ],
+  "residual": "50",
+  "absoluteResidual": "50",
+  "tolerance": "0",
+  "compiledCEL": "balanceEquation(...)"
+}
+```
+
+Balances, contributions, and residuals are strings so JSON clients cannot lose integer precision.
+The evidence source array keeps term order. The fingerprint and source IDs, not array positions, are
+the stable identifiers.
+
+### 5. `exchange_rate_bounds`
+
+Compares two differently denominated balances using the convention **quote major units per one base
+major unit**. Given minor-unit balances `B` and `Q`, and asset precisions `pB` and `pQ`:
+
+```text
+observed rate = (Q * 10^pB) / (B * 10^pQ)
+```
+
+The evaluator uses exact `big.Int` cross-multiplication; it never uses binary floating point or a
+rounded display value.
+
+```json
+{
+  "sources": [
+    {
+      "id": "eur",
+      "label": "EUR position",
+      "ledger": "treasury",
+      "query": { "$match": { "address": "position:eur" } },
+      "asset": "EUR/2"
+    },
+    {
+      "id": "usd",
+      "label": "USD valuation",
+      "ledger": "treasury",
+      "query": { "$match": { "address": "valuation:usd" } },
+      "asset": "USD/2"
+    }
+  ],
+  "baseSource": "eur",
+  "quoteSource": "usd",
+  "rate": {
+    "target": "1.10",
+    "toleranceBps": 25
+  }
+}
+```
+
+`rate` has exactly one of two shapes:
+
+```json
+{ "min": "1.075", "max": "1.125" }
+```
+
+```json
+{ "target": "1.10", "toleranceBps": 25 }
+```
+
+**Validation and boundaries**
+
+- `baseSource` and `quoteSource` refer to different declared source IDs.
+- The source array contains exactly those two sources.
+- `min`, `max`, and `target` are positive plain-decimal strings, with no sign or exponent and at
+  most 18 fractional digits.
+- Explicit bounds require both values and `min <= max`.
+- Target mode requires `toleranceBps` from 0 through 10,000. Its exact inclusive bounds are
+  `target × (10,000 ± toleranceBps) / 10,000`.
+- A value exactly on either bound passes.
+- Signs are preserved. Two negative balances yield a positive ratio; opposite signs yield a
+  negative ratio and fail positive bounds.
+- A zero quote balance is the defined rate zero. A zero base balance is undefined and produces a
+  failed outcome with `undefinedReason: "base_balance_zero"`; it does not raise an engine error.
+
+**Fingerprint** — `baseSource:<base-id>|quoteSource:<quote-id>`
+
+**Evidence**
+
+```json
+{
+  "schemaVersion": 2,
+  "operation": "exchange_rate_bounds",
+  "base": {
+    "id": "eur",
+    "label": "EUR position",
+    "kind": "ledger",
+    "asset": "EUR/2",
+    "balance": "10000",
+    "present": true
+  },
+  "quote": {
+    "id": "usd",
+    "label": "USD valuation",
+    "kind": "ledger",
+    "asset": "USD/2",
+    "balance": "11000",
+    "present": true
+  },
+  "observedRate": {
+    "numerator": "11",
+    "denominator": "10"
+  },
+  "effectiveBounds": {
+    "min": "1.09725",
+    "max": "1.10275"
+  },
+  "compiledCEL": "exchangeRateWithin(...)"
+}
+```
+
+When the base balance is zero, evidence omits `observedRate` and adds
+`"undefinedReason": "base_balance_zero"`.
+
+V2 evidence is deliberately separate from V1: it carries `schemaVersion: 2`, an operation
+discriminator, and named sources; it never emits `leftSource`, `leftBalance`, `rightSource`, or
+`rightBalance`.
+
+V2's CEL financial built-ins use exact `big.Int` / `big.Rat` arithmetic. The rule and evidence retain
+`compiledCEL` as the canonical explanation and cross-check surface; no binary floating point is used.
+
+---
+
+### 6. `source_consensus`
+
+Checks that several independent records of the same asset all exist and agree symmetrically:
+
+```text
+all sources present AND max(balance_i) - min(balance_i) <= tolerance
+```
+
+This is useful for a subledger, custodian mirror, processor report, and bank-reported value that
+should describe the same money. It is deliberately not “compare B, C, and D with A”: the verdict is
+based on the widest disagreement across every source.
+
+```json
+{
+  "sources": [
+    { "id": "subledger", "label": "Customer subledger", "ledger": "main", "query": { "$match": { "address": "customers:total" } }, "asset": "USD/2" },
+    { "id": "processor", "label": "Processor report", "kind": "account_metadata", "ledger": "processor", "query": { "$match": { "address": "reported:balance" } }, "metadataKey": "reported_balance", "asset": "USD/2" },
+    { "id": "bank", "label": "Bank statement", "kind": "account_metadata", "ledger": "bank", "query": { "$match": { "address": "statement:closing" } }, "metadataKey": "closing_balance", "asset": "USD/2" }
+  ],
+  "tolerance": "100"
+}
+```
+
+**Validation and verdict**
+
+- Two through 32 sources, all declaring the same asset.
+- `tolerance` is a non-negative integer string in that asset's minor units.
+- A missing ledger asset is explicit evidence (`present: false`) and fails the outcome even when its
+  zero value would otherwise fall inside the spread.
+- There is no quorum or “ignore missing” mode. All declared records participate.
+- Ties for minimum or maximum use the first source in request order, keeping evidence deterministic.
+
+**Fingerprint** — `asset:<asset>`
+
+Evidence includes the ordered source snapshots, `minimumSource`, `minimumBalance`, `maximumSource`,
+`maximumBalance`, `spread`, `tolerance`, `missingSources`, and `compiledCEL`.
+
+### 7. `coverage_ratio_bounds`
+
+Checks an exact ratio between two signed, multi-source portfolios of the same asset:
+
+```text
+minRatio <= sum(numerator contributions) / sum(denominator contributions) <= maxRatio
+```
+
+For example, liquid cash plus eligible securities can be compared with customer liabilities:
+
+```json
+{
+  "sources": [
+    { "id": "cash", "label": "Bank cash", "ledger": "treasury", "query": { "$match": { "address": "assets:cash:*" } }, "asset": "USD/2" },
+    { "id": "securities", "label": "Eligible securities", "ledger": "treasury", "query": { "$match": { "address": "assets:securities:*" } }, "asset": "USD/2" },
+    { "id": "encumbered", "label": "Encumbered reserves", "ledger": "treasury", "query": { "$match": { "address": "assets:encumbered:*" } }, "asset": "USD/2" },
+    { "id": "liabilities", "label": "Customer liabilities", "ledger": "main", "query": { "$match": { "address": "liabilities:customers:*" } }, "asset": "USD/2" }
+  ],
+  "numeratorTerms": [
+    { "source": "cash", "coefficient": 1 },
+    { "source": "securities", "coefficient": 1 },
+    { "source": "encumbered", "coefficient": -1 }
+  ],
+  "denominatorTerms": [
+    { "source": "liabilities", "coefficient": 1 }
+  ],
+  "ratio": { "target": "1.10", "toleranceBps": 500 }
+}
+```
+
+**Validation and boundaries**
+
+- Every source declares the same asset and is assigned exactly once across `numeratorTerms` and
+  `denominatorTerms`; unused, duplicated, and unknown IDs are rejected.
+- Both portfolios contain at least one term. Coefficients are non-zero signed integers.
+- `ratio` accepts the same exact `{min,max}` or `{target,toleranceBps}` shapes as
+  `exchange_rate_bounds`; bounds are inclusive and no binary floating point is used.
+- Missing ledger assets contribute explicit zero with `present: false` evidence.
+- A denominator total of zero fails with `undefinedReason: "denominator_total_zero"` and no
+  `observedRatio`; it is not an engine error.
+
+**Fingerprint** — `asset:<asset>`
+
+Evidence contains numerator and denominator portfolio totals, every signed contribution, the exact
+reduced `observedRatio` numerator/denominator, effective bounds, and `compiledCEL`.
+
+This remains separate from `exchange_rate_bounds`: FX compares two differently denominated sources
+with asset-precision conversion, while coverage compares two same-asset portfolios. It also remains
+separate from `balance_equation`: a ratio bound is scale-invariant and cannot be represented by one
+fixed residual tolerance.
 
 ---
 

--- a/docs/technical/workflows.md
+++ b/docs/technical/workflows.md
@@ -1,6 +1,6 @@
 # Lifecycle Workflows
 
-The V1 product surface is a **business lifecycle**, not a rules engine. This document is the visual reference for that lifecycle:
+The V1 and V2 product surfaces share a **business lifecycle**, not a generic rules engine. This document is the visual reference for that lifecycle:
 
 > **Observe → Detect → Alert → Evidence → Resolve or Accept**
 
@@ -28,7 +28,8 @@ sequenceDiagram
     participant Eng as engine.Engine
     participant L   as Ledger (_recon)
 
-    U->>Svc: POST /rules { templateKind, templateSpec, … }
+    U->>Svc: POST /rules or /v2/rules { templateKind, templateSpec, … }
+    Note over Svc: route selects immutable contractVersion<br/>V1=1, V2=2
     Svc->>Reg: Get(templateKind).Validate(spec)
     alt invalid spec
         Reg-->>Svc: ErrInvalidSpec
@@ -44,6 +45,8 @@ sequenceDiagram
 **Notes**
 
 - The rule is a typed-metadata account `rule:{id}` on `_recon` — no relational row.
+- V1 and V2 use separate route-scoped registries. The version predicate is applied before lists and
+  point operations; an ID used through the wrong version returns `404`.
 - `Explain()` returns one representative CEL string for `compiled_cel` (explainability); real
   evaluation re-renders the per-asset CEL at run time.
 
@@ -57,14 +60,16 @@ sequenceDiagram
     participant Trig as Trigger (cron / POST evaluate)
     participant Svc  as Service.EvaluateRule
     participant Reg  as templates.Registry
-    participant Data as data-ledgers A/B
+    participant Data as data-ledgers / metadata sources
     participant L    as Ledger (_recon)
 
     Trig->>Svc: evaluate(rule)
     Svc->>Reg: Evaluate(spec, resolvers, {PIT})
-    Reg->>Data: AggregateVolumes(query)  (live, per source)
-    Data-->>Reg: balances (per asset)
-    Note over Reg: direct big.Int math per asset;<br/>render compiledCEL into evidence
+    loop Each named source (2–32 in V2)
+        Reg->>Data: AggregateVolumes/ListAccounts(query) (live)
+        Data-->>Reg: declared-asset balance + presence
+    end
+    Note over Reg: exact big.Int/big.Rat financial built-ins;<br/>render compiledCEL into evidence
     Reg-->>Svc: []Outcome  (one per fingerprint axis)
     Svc->>L: RecordCapture — mint 1 CAPTURE (snapshot in tx metadata)
     loop For each failing outcome
@@ -81,19 +86,23 @@ sequenceDiagram
 - **Live reads, no checkpoint** (ADR-003). Each `ledgerSet` source is one `AggregateVolumes` — an
   internally consistent server-side snapshot, so a **single-ledger** universe is skew-free for free.
   **Cross-ledger** rules read each side separately; the transient skew is absorbed by the template's
-  `tolerance`. Built-ins evaluate in **typed `big.Int` math** — the CEL kernel is not run at
-  evaluation time (it renders `compiledCEL` into `evidence` for explainability only).
+  `tolerance`. Typed templates use authoritative **`big.Int` / `big.Rat` math** and retain an exact
+  `compiledCEL`; equivalent financial built-ins support explainability and cross-checking without
+  binary floating point.
+- **V2 evidence is self-describing.** Equation outcomes retain every named source balance,
+  coefficient and contribution plus the residual. Exchange-rate outcomes retain the base/quote
+  snapshots, exact numerator/denominator and effective bounds. Both carry `schemaVersion: 2` and
+  `compiledCEL`; neither uses V1 left/right evidence keys.
 - **A capture per evaluation** (ADR-003). `RecordCapture` mints one `CAPTURE` into
   `capture:rule:{id}:per:{p}`; the observed snapshot (`verdict`, `trigger`, `evidence`, …) rides the
   `COMMITTED_TRANSACTION` metadata — the durable, receipt-signed "what reconciled and when", covering
-  passes as well as breaks. Its bounded evidence contains every failing outcome and only those
-  passing outcomes that resolve an active alert. A mixed run can therefore retain failure evidence
-  for one fingerprint and successful resolution evidence for another. It is written **before** the
+  passes as well as breaks. Its evidence contains every outcome and the exact values used for the
+  verdict, including successful outcomes that do not mutate an alert. It is written **before** the
   planned alert transitions.
 - The `Outcome` list covers every asset the template touched — passing included — so the service
-  can plan **auto-resolution** from the same observed values before persisting the capture. Passing
-  outcomes with no active alert are not retained; active fingerprints that disappear still resolve
-  without evidence because no outcome was observed for them.
+  can plan **auto-resolution** from the same observed values before persisting the capture. Active
+  fingerprints that disappear still resolve without outcome evidence because this evaluation did
+  not observe that fingerprint.
 - **The capture is the durable evaluation record** (ADR-003, revising RFC §4.4.2) — an immutable
   `_recon` transaction, not a queryable Postgres evaluation table (`CreateEvaluation` is a no-op).
   The run result is also returned; the break `evidence` is additionally durable on `alert:item`. The
@@ -211,7 +220,8 @@ flowchart TB
 A kernel/resolver failure (resolver timeout, CEL builtin throw, budget exceeded) is not a
 *financial* alert, so it opens a synthetic `engine.error` meta-alert (same alert infrastructure, a
 distinct `engine.error` fingerprint + `kind: engine.error` label) instead of a data alert. The
-evaluation returns `ERROR` (non-durable). Translation lives in
+evaluation returns `ERROR` and records an immutable error capture before the
+meta-alert is opened. Translation lives in
 [engine/errors.go](../../internal/engine/errors.go).
 
 ---
@@ -221,7 +231,7 @@ evaluation returns `ERROR` (non-durable). Translation lives in
 ```mermaid
 flowchart LR
     Tick[Evaluate @ T] --> Read["Each ledgerSet source →<br/>AggregateVolumes (live, per source)"]
-    Read --> Math[Template direct big.Int math]
+    Read --> Math["Exact big.Int / big.Rat<br/>financial built-ins"]
     Math --> Cap["Record capture on _recon<br/>(immutable snapshot in tx metadata)"]
 ```
 
@@ -242,18 +252,19 @@ uniquely offered, and discarded anyway — is deferred to a future ledger primit
 
 ---
 
-## 8. Audit history & delivery — the ledger log
+## 8. Combined rule history and delivery
 
-There is **no `alert_event` table**. The control-ledger's ordered, append-only log *is* the audit
-history: every transition is a `COMMITTED_TRANSACTION` (marker move + `account_metadata`) or, for
-snooze/unsnooze, a `SAVED_METADATA`/`DELETED_METADATA` entry — each carrying the self-describing
-`last_transition` envelope. The ledger already gives the cryptographic transaction-log guarantees
-recon used to aspire to.
+There is **no `alert_event` table**. Every rule change, evaluation capture, and
+alert transition touches `activity:rule:{ruleID}` and carries a semantic event
+envelope. The same transaction mutates current state and appends history.
+`GET /rules/{id}/timeline` and its V2 counterpart query this address through the
+Ledger transaction-address index and expose one ordered feed.
 
 - **Delivery** rides the ledger's native **events sink** ([architecture.md](./architecture.md#event-delivery)):
   when `--events-sink-url` is set, recon provisions an HTTP webhook sink for
   `[COMMITTED_TRANSACTION, SAVED_METADATA, DELETED_METADATA]`; consumers filter on
-  `event.ledger == _recon`.
-- **`GET /alerts/{id}/events` (`ListAlertEvents`) returns empty today** — paginated per-alert
-  history needs a downstream queryable sink (ClickHouse/Databricks), because the ledger log has no
-  per-account filter (RFC §10). Deferred.
+  the configured control-ledger name. Current rule, evaluation, and alert activity—including
+  snooze/unsnooze—is transaction-backed; metadata event types remain subscribed for compatibility.
+- The rule timeline is the canonical product read model. The existing per-alert
+  events endpoint remains a compatibility surface and can later be projected
+  from the same journal.

--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/formancehq/go-libs/api"
+	"github.com/formancehq/go-libs/bun/bunpaginate"
+	"github.com/formancehq/reconciliation/internal/api/backend"
+	"github.com/formancehq/reconciliation/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+func listRuleActivitiesHandler(b backend.Backend) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := uuid.Parse(chi.URLParam(r, "ruleID"))
+		if err != nil {
+			api.BadRequest(w, ErrInvalidID, err)
+			return
+		}
+		q := store.GetRuleActivitiesQuery{}
+		if raw := r.URL.Query().Get(QueryKeyCursor); raw != "" {
+			if err := bunpaginate.UnmarshalCursor(raw, &q); err != nil {
+				api.BadRequest(w, ErrValidation, fmt.Errorf("invalid '%s' query param", QueryKeyCursor))
+				return
+			}
+		} else {
+			opts, err := getPaginatedQueryOptionsRuleActivities(r)
+			if err != nil {
+				api.BadRequest(w, ErrValidation, err)
+				return
+			}
+			q = store.NewGetRuleActivitiesQuery(*opts)
+		}
+		cursor, err := b.GetService().ListRuleActivities(r.Context(), id, q)
+		if err != nil {
+			handleServiceErrors(w, r, err)
+			return
+		}
+		api.RenderCursor(w, *cursor)
+	}
+}

--- a/internal/api/alert.go
+++ b/internal/api/alert.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/reconciliation/internal/api/backend"
 	"github.com/formancehq/reconciliation/internal/api/service"
+	"github.com/formancehq/reconciliation/internal/contractversion"
 	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/store"
 	"github.com/go-chi/chi/v5"
@@ -19,6 +20,7 @@ import (
 type alertResponse struct {
 	ID               string             `json:"id"`
 	RuleID           string             `json:"ruleID"`
+	PeriodID         string             `json:"periodID,omitempty"`
 	Fingerprint      string             `json:"fingerprint"`
 	Status           string             `json:"status"`
 	Severity         string             `json:"severity"`
@@ -33,10 +35,11 @@ type alertResponse struct {
 	Labels           map[string]string  `json:"labels,omitempty"`
 	CreatedAt        time.Time          `json:"createdAt"`
 	UpdatedAt        time.Time          `json:"updatedAt"`
+	ContractVersion  int                `json:"contractVersion,omitempty"`
 }
 
 func renderAlert(a *models.Alert) *alertResponse {
-	return &alertResponse{
+	response := &alertResponse{
 		ID:               a.ID.String(),
 		RuleID:           a.RuleID.String(),
 		Fingerprint:      a.Fingerprint,
@@ -54,6 +57,11 @@ func renderAlert(a *models.Alert) *alertResponse {
 		CreatedAt:        a.CreatedAt,
 		UpdatedAt:        a.UpdatedAt,
 	}
+	if a.ContractVersion.Effective() == models.ContractVersionV2 {
+		response.ContractVersion = int(models.ContractVersionV2)
+		response.PeriodID = a.PeriodID
+	}
+	return response
 }
 
 type alertEventResponse struct {
@@ -129,6 +137,12 @@ func listAlertsHandler(b backend.Backend) http.HandlerFunc {
 		cursor, err := b.GetService().ListAlerts(r.Context(), q)
 		if err != nil {
 			handleServiceErrors(w, r, err)
+			return
+		}
+		if version, _ := contractversion.FromContext(r.Context()); version == models.ContractVersionV2 {
+			api.RenderCursor(w, *bunpaginate.MapCursor(cursor, func(alert models.Alert) *alertResponse {
+				return renderAlert(&alert)
+			}))
 			return
 		}
 		api.RenderCursor(w, *cursor)

--- a/internal/api/backend/backend.go
+++ b/internal/api/backend/backend.go
@@ -21,6 +21,7 @@ type Service interface {
 	DeleteRule(ctx context.Context, id uuid.UUID) error
 	EvaluateRule(ctx context.Context, id uuid.UUID, req service.EvaluateRuleRequest) (*models.Evaluation, error)
 	ListCaptures(ctx context.Context, ruleID uuid.UUID, q store.GetCapturesQuery) (*bunpaginate.Cursor[models.Capture], error)
+	ListRuleActivities(ctx context.Context, ruleID uuid.UUID, q store.GetRuleActivitiesQuery) (*bunpaginate.Cursor[models.RuleActivity], error)
 
 	// V1 — Alert
 	GetAlert(ctx context.Context, id uuid.UUID) (*models.Alert, error)

--- a/internal/api/backend/backend_generated.go
+++ b/internal/api/backend/backend_generated.go
@@ -194,6 +194,21 @@ func (mr *MockServiceMockRecorder) ListCaptures(ctx, ruleID, q any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCaptures", reflect.TypeOf((*MockService)(nil).ListCaptures), ctx, ruleID, q)
 }
 
+// ListRuleActivities mocks base method.
+func (m *MockService) ListRuleActivities(ctx context.Context, ruleID uuid.UUID, q store.GetRuleActivitiesQuery) (*bunpaginate.Cursor[models.RuleActivity], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRuleActivities", ctx, ruleID, q)
+	ret0, _ := ret[0].(*bunpaginate.Cursor[models.RuleActivity])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRuleActivities indicates an expected call of ListRuleActivities.
+func (mr *MockServiceMockRecorder) ListRuleActivities(ctx, ruleID, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleActivities", reflect.TypeOf((*MockService)(nil).ListRuleActivities), ctx, ruleID, q)
+}
+
 // ListRules mocks base method.
 func (m *MockService) ListRules(ctx context.Context, q store.GetRulesQuery) (*bunpaginate.Cursor[models.Rule], error) {
 	m.ctrl.T.Helper()

--- a/internal/api/capture.go
+++ b/internal/api/capture.go
@@ -16,19 +16,25 @@ import (
 )
 
 type captureResponse struct {
-	TransactionID uint64          `json:"transactionID"`
-	RuleID        string          `json:"ruleID"`
-	PeriodID      string          `json:"periodID"`
-	EvaluationID  string          `json:"evaluationID"`
-	TemplateKind  string          `json:"templateKind"`
-	Verdict       string          `json:"verdict"`
-	Trigger       string          `json:"trigger"`
-	CapturedAt    time.Time       `json:"capturedAt"`
-	Evidence      json.RawMessage `json:"evidence,omitempty"`
+	TransactionID   uint64          `json:"transactionID"`
+	RuleID          string          `json:"ruleID"`
+	PeriodID        string          `json:"periodID"`
+	EvaluationID    string          `json:"evaluationID"`
+	TemplateKind    string          `json:"templateKind"`
+	Verdict         string          `json:"verdict"`
+	Trigger         string          `json:"trigger"`
+	CapturedAt      time.Time       `json:"capturedAt"`
+	Evidence        json.RawMessage `json:"evidence,omitempty"`
+	ContractVersion int             `json:"contractVersion,omitempty"`
+	RuleRevision    string          `json:"ruleRevision,omitempty"`
+	PIT             *time.Time      `json:"pit,omitempty"`
+	StartedAt       *time.Time      `json:"startedAt,omitempty"`
+	Result          string          `json:"result,omitempty"`
+	Error           string          `json:"error,omitempty"`
 }
 
 func renderCapture(c *models.Capture) *captureResponse {
-	return &captureResponse{
+	response := &captureResponse{
 		TransactionID: c.TransactionID,
 		RuleID:        c.RuleID.String(),
 		PeriodID:      c.PeriodID,
@@ -39,6 +45,15 @@ func renderCapture(c *models.Capture) *captureResponse {
 		CapturedAt:    c.CapturedAt,
 		Evidence:      c.Evidence,
 	}
+	if c.ContractVersion.Effective() == models.ContractVersionV2 {
+		response.ContractVersion = int(models.ContractVersionV2)
+		response.RuleRevision = c.RuleRevision
+		response.PIT = &c.PIT
+		response.StartedAt = &c.StartedAt
+		response.Result = string(c.Result)
+		response.Error = c.Error
+	}
+	return response
 }
 
 // listRuleCapturesHandler returns a rule's evaluation history — the immutable

--- a/internal/api/contract_version_handlers_test.go
+++ b/internal/api/contract_version_handlers_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sharedapi "github.com/formancehq/go-libs/api"
+	"github.com/formancehq/go-libs/auth"
+	"github.com/formancehq/go-libs/v5/pkg/audit"
+	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
+	"github.com/formancehq/reconciliation/internal/api/service"
+	"github.com/formancehq/reconciliation/internal/contractversion"
+	"github.com/formancehq/reconciliation/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestV1RenderersDoNotExposeV2AuditFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	ruleJSON, err := json.Marshal(renderRule(&models.Rule{
+		ID: uuid.New(), ContractVersion: models.ContractVersionV1, Revision: "sha256:revision",
+		Name: "v1", TemplateKind: models.TemplateSourceParity, TemplateSpec: json.RawMessage(`{}`),
+		Enabled: true, Severity: models.SeverityMedium, Cadence: models.CadenceContinuous,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, err)
+	var rule map[string]any
+	require.NoError(t, json.Unmarshal(ruleJSON, &rule))
+	require.NotContains(t, rule, "contractVersion")
+	require.NotContains(t, rule, "revision")
+
+	captureJSON, err := json.Marshal(renderCapture(&models.Capture{
+		TransactionID: 1, ContractVersion: models.ContractVersionV1, RuleID: uuid.New(),
+		EvaluationID: uuid.New(), PeriodID: "continuous", TemplateKind: string(models.TemplateSourceParity),
+		Verdict: "pass", Trigger: "manual", CapturedAt: now, RuleRevision: "sha256:revision",
+		PIT: now, StartedAt: now, Result: models.EvaluationPass,
+	}))
+	require.NoError(t, err)
+	var capture map[string]any
+	require.NoError(t, json.Unmarshal(captureJSON, &capture))
+	for _, field := range []string{"contractVersion", "ruleRevision", "pit", "startedAt", "result", "error"} {
+		require.NotContains(t, capture, field)
+	}
+}
+
+func TestV2DoesNotExposeDeferredAlertEventsRoute(t *testing.T) {
+	t.Parallel()
+
+	b, _ := newTestingBackend(t)
+	router := newRouter(b, sharedapi.ServiceInfo{}, auth.NewNoAuth(), nil, publish.InMemory(), audit.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/v2/alerts/"+uuid.NewString()+"/events", nil)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	require.Equal(t, http.StatusNotFound, res.Code)
+}
+
+func TestV2CreateRouteScopesRequestAndRendersVersion(t *testing.T) {
+	t.Parallel()
+
+	b, svc := newTestingBackend(t)
+	svc.EXPECT().CreateRule(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *service.CreateRuleRequest) (*models.Rule, error) {
+		version, ok := contractversion.FromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, models.ContractVersionV2, version)
+		return &models.Rule{
+			ID:              uuid.New(),
+			ContractVersion: models.ContractVersionV2,
+			Name:            req.Name,
+			TemplateKind:    req.TemplateKind,
+			TemplateSpec:    req.TemplateSpec,
+			CompiledCEL:     "balanceEquation(...) ",
+		}, nil
+	})
+
+	router := newRouter(b, sharedapi.ServiceInfo{}, auth.NewNoAuth(), nil, publish.InMemory(), audit.Config{})
+	req := httptest.NewRequest(http.MethodPost, "/v2/rules", strings.NewReader(`{"name":"eq","templateKind":"balance_equation","templateSpec":{}}`))
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusCreated, res.Code)
+	var payload struct {
+		Data struct {
+			ContractVersion int    `json:"contractVersion"`
+			CompiledCEL     string `json:"compiledCEL"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(res.Body.Bytes(), &payload))
+	require.Equal(t, 2, payload.Data.ContractVersion)
+	require.Equal(t, "balanceEquation(...) ", payload.Data.CompiledCEL)
+}

--- a/internal/api/evaluation.go
+++ b/internal/api/evaluation.go
@@ -8,19 +8,20 @@ import (
 )
 
 type evaluationResponse struct {
-	ID        string          `json:"id"`
-	RuleID    string          `json:"ruleID"`
-	StartedAt time.Time       `json:"startedAt"`
-	EndedAt   time.Time       `json:"endedAt"`
-	Result    string          `json:"result"`
-	Evidence  json.RawMessage `json:"evidence,omitempty"`
-	Error     string          `json:"error,omitempty"`
-	CostUnits int64           `json:"costUnits"`
-	CreatedAt time.Time       `json:"createdAt"`
+	ID              string          `json:"id"`
+	RuleID          string          `json:"ruleID"`
+	StartedAt       time.Time       `json:"startedAt"`
+	EndedAt         time.Time       `json:"endedAt"`
+	Result          string          `json:"result"`
+	Evidence        json.RawMessage `json:"evidence,omitempty"`
+	Error           string          `json:"error,omitempty"`
+	CostUnits       int64           `json:"costUnits"`
+	CreatedAt       time.Time       `json:"createdAt"`
+	ContractVersion int             `json:"contractVersion,omitempty"`
 }
 
 func renderEvaluation(ev *models.Evaluation) *evaluationResponse {
-	return &evaluationResponse{
+	response := &evaluationResponse{
 		ID:        ev.ID.String(),
 		RuleID:    ev.RuleID.String(),
 		StartedAt: ev.StartedAt,
@@ -31,4 +32,8 @@ func renderEvaluation(ev *models.Evaluation) *evaluationResponse {
 		CostUnits: ev.CostUnits,
 		CreatedAt: ev.CreatedAt,
 	}
+	if ev.ContractVersion.Effective() == models.ContractVersionV2 {
+		response.ContractVersion = int(models.ContractVersionV2)
+	}
+	return response
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,7 +14,39 @@ import (
 	"github.com/formancehq/go-libs/auth"
 	"github.com/formancehq/go-libs/health"
 	"github.com/formancehq/reconciliation/internal/api/backend"
+	"github.com/formancehq/reconciliation/internal/contractversion"
+	"github.com/formancehq/reconciliation/internal/models"
 )
+
+func contractVersionMiddleware(version models.ContractVersion) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(contractversion.WithContext(r.Context(), version)))
+		})
+	}
+}
+
+func mountRuleAndAlertRoutes(r chi.Router, b backend.Backend, includeDeferredAlertEvents bool) {
+	r.Post("/rules", createRuleHandler(b))
+	r.Get("/rules", listRulesHandler(b))
+	r.Get("/rules/{ruleID}", getRuleHandler(b))
+	r.Patch("/rules/{ruleID}", patchRuleHandler(b))
+	r.Delete("/rules/{ruleID}", deleteRuleHandler(b))
+	r.Post("/rules/{ruleID}/evaluate", evaluateRuleHandler(b))
+	r.Get("/rules/{ruleID}/captures", listRuleCapturesHandler(b))
+	r.Get("/rules/{ruleID}/timeline", listRuleActivitiesHandler(b))
+
+	r.Get("/alerts", listAlertsHandler(b))
+	r.Get("/alerts/{alertID}", getAlertHandler(b))
+	if includeDeferredAlertEvents {
+		r.Get("/alerts/{alertID}/events", listAlertEventsHandler(b))
+	}
+	r.Post("/alerts/{alertID}/ack", ackAlertHandler(b))
+	r.Post("/alerts/{alertID}/resolve", resolveAlertHandler(b))
+	r.Post("/alerts/{alertID}/accept", acceptAlertHandler(b))
+	r.Post("/alerts/{alertID}/snooze", snoozeAlertHandler(b))
+	r.Post("/alerts/{alertID}/unsnooze", unsnoozeAlertHandler(b))
+}
 
 func newRouter(
 	b backend.Backend,
@@ -39,23 +71,14 @@ func newRouter(
 		r.Use(auth.Middleware(authenticator))
 		r.Use(service.OTLPMiddleware("reconciliation", serviceInfo.Debug))
 
-		// V1 — Rule / Evaluation / Alert
-		r.Post("/rules", createRuleHandler(b))
-		r.Get("/rules", listRulesHandler(b))
-		r.Get("/rules/{ruleID}", getRuleHandler(b))
-		r.Patch("/rules/{ruleID}", patchRuleHandler(b))
-		r.Delete("/rules/{ruleID}", deleteRuleHandler(b))
-		r.Post("/rules/{ruleID}/evaluate", evaluateRuleHandler(b))
-		r.Get("/rules/{ruleID}/captures", listRuleCapturesHandler(b))
-
-		r.Get("/alerts", listAlertsHandler(b))
-		r.Get("/alerts/{alertID}", getAlertHandler(b))
-		r.Get("/alerts/{alertID}/events", listAlertEventsHandler(b))
-		r.Post("/alerts/{alertID}/ack", ackAlertHandler(b))
-		r.Post("/alerts/{alertID}/resolve", resolveAlertHandler(b))
-		r.Post("/alerts/{alertID}/accept", acceptAlertHandler(b))
-		r.Post("/alerts/{alertID}/snooze", snoozeAlertHandler(b))
-		r.Post("/alerts/{alertID}/unsnooze", unsnoozeAlertHandler(b))
+		r.Group(func(r chi.Router) {
+			r.Use(contractVersionMiddleware(models.ContractVersionV1))
+			mountRuleAndAlertRoutes(r, b, true)
+		})
+		r.Route("/v2", func(r chi.Router) {
+			r.Use(contractVersionMiddleware(models.ContractVersionV2))
+			mountRuleAndAlertRoutes(r, b, false)
+		})
 	})
 
 	return r

--- a/internal/api/rule.go
+++ b/internal/api/rule.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/reconciliation/internal/api/backend"
 	"github.com/formancehq/reconciliation/internal/api/service"
+	"github.com/formancehq/reconciliation/internal/contractversion"
 	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/store"
 	"github.com/go-chi/chi/v5"
@@ -17,23 +18,25 @@ import (
 )
 
 type ruleResponse struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	TemplateKind  string            `json:"templateKind"`
-	TemplateSpec  json.RawMessage   `json:"templateSpec"`
-	CompiledCEL   string            `json:"compiledCEL,omitempty"`
-	Enabled       bool              `json:"enabled"`
-	Severity      string            `json:"severity"`
-	Cadence       string            `json:"cadence"`
-	Schedule      *models.Schedule  `json:"schedule,omitempty"`
-	Notifications []string          `json:"notifications,omitempty"`
-	Labels        map[string]string `json:"labels,omitempty"`
-	CreatedAt     time.Time         `json:"createdAt"`
-	UpdatedAt     time.Time         `json:"updatedAt"`
+	ID              string            `json:"id"`
+	Name            string            `json:"name"`
+	TemplateKind    string            `json:"templateKind"`
+	TemplateSpec    json.RawMessage   `json:"templateSpec"`
+	CompiledCEL     string            `json:"compiledCEL,omitempty"`
+	Enabled         bool              `json:"enabled"`
+	Severity        string            `json:"severity"`
+	Cadence         string            `json:"cadence"`
+	Schedule        *models.Schedule  `json:"schedule,omitempty"`
+	Notifications   []string          `json:"notifications,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	CreatedAt       time.Time         `json:"createdAt"`
+	UpdatedAt       time.Time         `json:"updatedAt"`
+	ContractVersion int               `json:"contractVersion,omitempty"`
+	Revision        string            `json:"revision,omitempty"`
 }
 
 func renderRule(r *models.Rule) *ruleResponse {
-	return &ruleResponse{
+	response := &ruleResponse{
 		ID:            r.ID.String(),
 		Name:          r.Name,
 		TemplateKind:  string(r.TemplateKind),
@@ -48,6 +51,11 @@ func renderRule(r *models.Rule) *ruleResponse {
 		CreatedAt:     r.CreatedAt,
 		UpdatedAt:     r.UpdatedAt,
 	}
+	if r.ContractVersion.Effective() == models.ContractVersionV2 {
+		response.ContractVersion = int(models.ContractVersionV2)
+		response.Revision = r.Revision
+	}
+	return response
 }
 
 func createRuleHandler(b backend.Backend) http.HandlerFunc {
@@ -167,6 +175,12 @@ func listRulesHandler(b backend.Backend) http.HandlerFunc {
 		cursor, err := b.GetService().ListRules(r.Context(), q)
 		if err != nil {
 			handleServiceErrors(w, r, err)
+			return
+		}
+		if version, _ := contractversion.FromContext(r.Context()); version == models.ContractVersionV2 {
+			api.RenderCursor(w, *bunpaginate.MapCursor(cursor, func(rule models.Rule) *ruleResponse {
+				return renderRule(&rule)
+			}))
 			return
 		}
 		api.RenderCursor(w, *cursor)

--- a/internal/api/service/alert.go
+++ b/internal/api/service/alert.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
+	"github.com/formancehq/reconciliation/internal/contractversion"
 	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/store"
 	"github.com/google/uuid"
@@ -58,6 +59,9 @@ func (s *Service) AckAlert(ctx context.Context, id uuid.UUID, req *AckAlertReque
 	if req == nil || req.By == "" {
 		return nil, errors.New("ack: 'by' is required")
 	}
+	if _, err := s.getAlertForContract(ctx, id); err != nil {
+		return nil, err
+	}
 	ack := &models.Ack{
 		By:   req.By,
 		At:   time.Now().UTC(),
@@ -72,6 +76,9 @@ func (s *Service) AckAlert(ctx context.Context, id uuid.UUID, req *AckAlertReque
 func (s *Service) ResolveAlert(ctx context.Context, id uuid.UUID, req *ResolveAlertRequest) (*models.Alert, error) {
 	if req == nil || req.By == "" {
 		return nil, errors.New("resolve: 'by' is required")
+	}
+	if _, err := s.getAlertForContract(ctx, id); err != nil {
+		return nil, err
 	}
 	resolution := &models.Resolution{
 		Kind:            models.ResolutionFixedByBooking,
@@ -94,7 +101,7 @@ func (s *Service) AcceptAlert(ctx context.Context, id uuid.UUID, req *AcceptAler
 		return nil, errors.New("accept: 'note' is required for business acceptance")
 	}
 
-	current, err := s.store.GetAlert(ctx, id)
+	current, err := s.getAlertForContract(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +133,9 @@ func (s *Service) SnoozeAlert(ctx context.Context, id uuid.UUID, req *SnoozeAler
 	if !req.Until.After(time.Now().UTC()) {
 		return nil, errors.New("snooze: 'until' must be in the future")
 	}
+	if _, err := s.getAlertForContract(ctx, id); err != nil {
+		return nil, err
+	}
 	return s.store.SnoozeAlert(ctx, id, req.Until, req.By, req.Note)
 }
 
@@ -135,16 +145,22 @@ func (s *Service) UnsnoozeAlert(ctx context.Context, id uuid.UUID, req *Unsnooze
 	if req == nil || req.By == "" {
 		return nil, errors.New("unsnooze: 'by' is required")
 	}
+	if _, err := s.getAlertForContract(ctx, id); err != nil {
+		return nil, err
+	}
 	return s.store.UnsnoozeAlert(ctx, id, req.By)
 }
 
 // GetAlert returns the alert or store.ErrNotFound.
 func (s *Service) GetAlert(ctx context.Context, id uuid.UUID) (*models.Alert, error) {
-	return s.store.GetAlert(ctx, id)
+	return s.getAlertForContract(ctx, id)
 }
 
 // ListAlerts is a passthrough — filters live in store.
 func (s *Service) ListAlerts(ctx context.Context, q store.GetAlertsQuery) (*bunpaginate.Cursor[models.Alert], error) {
+	if version, ok := contractversion.FromContext(ctx); ok {
+		q.Options.Options.ContractVersion = &version
+	}
 	return s.store.ListAlerts(ctx, q)
 }
 
@@ -153,6 +169,9 @@ func (s *Service) ListAlerts(ctx context.Context, q store.GetAlertsQuery) (*bunp
 // unbounded (one row per failing evaluation). This is the API surface for the
 // "timeline" view and any future audit-export tooling.
 func (s *Service) ListAlertEvents(ctx context.Context, alertID uuid.UUID, q store.GetAlertEventsQuery) (*bunpaginate.Cursor[models.AlertEvent], error) {
+	if _, err := s.getAlertForContract(ctx, alertID); err != nil {
+		return nil, err
+	}
 	return s.store.ListAlertEvents(ctx, alertID, q)
 }
 
@@ -161,6 +180,12 @@ func (s *Service) ListAlertEvents(ctx context.Context, alertID uuid.UUID, q stor
 // "reconciliation history" view: every run of a rule with its verdict, trigger
 // and observed evidence, read live from the control ledger.
 func (s *Service) ListCaptures(ctx context.Context, ruleID uuid.UUID, q store.GetCapturesQuery) (*bunpaginate.Cursor[models.Capture], error) {
+	if _, err := s.getRuleForContract(ctx, ruleID); err != nil {
+		return nil, err
+	}
+	if version, ok := contractversion.FromContext(ctx); ok {
+		q.Options.Options.ContractVersion = &version
+	}
 	return s.store.ListCaptures(ctx, ruleID, q)
 }
 

--- a/internal/api/service/contract_version.go
+++ b/internal/api/service/contract_version.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/formancehq/reconciliation/internal/contractversion"
+	"github.com/formancehq/reconciliation/internal/models"
+	"github.com/formancehq/reconciliation/internal/store"
+	"github.com/google/uuid"
+)
+
+func createContractVersion(ctx context.Context) models.ContractVersion {
+	if version, ok := contractversion.FromContext(ctx); ok {
+		return version
+	}
+	return models.ContractVersionV1
+}
+
+func requireContractVersion(ctx context.Context, actual models.ContractVersion) error {
+	expected, scoped := contractversion.FromContext(ctx)
+	if scoped && actual.Effective() != expected {
+		return fmt.Errorf("contract version mismatch: %w", store.ErrNotFound)
+	}
+	return nil
+}
+
+func validateTemplateContract(version models.ContractVersion, kind models.TemplateKind) error {
+	switch version.Effective() {
+	case models.ContractVersionV1:
+		switch kind {
+		case models.TemplateLedgerInvariant, models.TemplateSourceParity, models.TemplateAccountThreshold:
+			return nil
+		}
+	case models.ContractVersionV2:
+		switch kind {
+		case models.TemplateBalanceEquation, models.TemplateExchangeRateBounds,
+			models.TemplateSourceConsensus, models.TemplateCoverageRatioBounds:
+			return nil
+		}
+	}
+	return fmt.Errorf("template kind %q is not available in contract V%d", kind, version.Effective())
+}
+
+func (s *Service) getRuleForContract(ctx context.Context, id uuid.UUID) (*models.Rule, error) {
+	rule, err := s.store.GetRule(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireContractVersion(ctx, rule.ContractVersion); err != nil {
+		return nil, err
+	}
+	return rule, nil
+}
+
+func (s *Service) getAlertForContract(ctx context.Context, id uuid.UUID) (*models.Alert, error) {
+	alert, err := s.store.GetAlert(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireContractVersion(ctx, alert.ContractVersion); err != nil {
+		return nil, err
+	}
+	return alert, nil
+}

--- a/internal/api/service/contract_version_test.go
+++ b/internal/api/service/contract_version_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/formancehq/reconciliation/internal/contractversion"
+	"github.com/formancehq/reconciliation/internal/models"
+	"github.com/formancehq/reconciliation/internal/store"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContractVersionTemplateCatalogsAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateTemplateContract(models.ContractVersionV1, models.TemplateSourceParity))
+	require.Error(t, validateTemplateContract(models.ContractVersionV1, models.TemplateBalanceEquation))
+	require.NoError(t, validateTemplateContract(models.ContractVersionV2, models.TemplateBalanceEquation))
+	require.NoError(t, validateTemplateContract(models.ContractVersionV2, models.TemplateExchangeRateBounds))
+	require.NoError(t, validateTemplateContract(models.ContractVersionV2, models.TemplateSourceConsensus))
+	require.NoError(t, validateTemplateContract(models.ContractVersionV2, models.TemplateCoverageRatioBounds))
+	require.Error(t, validateTemplateContract(models.ContractVersionV2, models.TemplateSourceParity))
+}
+
+func TestRuleOperationsHideCrossVersionIDs(t *testing.T) {
+	t.Parallel()
+
+	svc, st := newOrchestrationService(t, &orchestrationLedger{})
+	id := uuid.New()
+	st.rules[id] = &models.Rule{ID: id, ContractVersion: models.ContractVersionV2, Name: "v2", Enabled: true}
+	ctx := contractversion.WithContext(context.Background(), models.ContractVersionV1)
+
+	_, err := svc.GetRule(ctx, id)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	name := "mutated"
+	err = svc.PatchRule(ctx, id, store.RulePatch{Name: &name})
+	require.ErrorIs(t, err, store.ErrNotFound)
+	require.Equal(t, "v2", st.rules[id].Name)
+
+	err = svc.DeleteRule(ctx, id)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	require.Contains(t, st.rules, id)
+
+	_, err = svc.EvaluateRule(ctx, id, EvaluateRuleRequest{})
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	_, err = svc.ListCaptures(ctx, id, store.GetCapturesQuery{})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestAlertOperationsHideCrossVersionIDs(t *testing.T) {
+	t.Parallel()
+
+	svc, st := newOrchestrationService(t, &orchestrationLedger{})
+	id := uuid.New()
+	st.alerts[id] = &models.Alert{ID: id, ContractVersion: models.ContractVersionV2, Status: models.AlertOpen}
+	ctx := contractversion.WithContext(context.Background(), models.ContractVersionV1)
+
+	_, err := svc.GetAlert(ctx, id)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = svc.AckAlert(ctx, id, &AckAlertRequest{By: "ops"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = svc.ResolveAlert(ctx, id, &ResolveAlertRequest{By: "ops"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = svc.AcceptAlert(ctx, id, &AcceptAlertRequest{By: "ops", Note: "accepted"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = svc.UnsnoozeAlert(ctx, id, &UnsnoozeAlertRequest{By: "ops"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = svc.ListAlertEvents(ctx, id, store.GetAlertEventsQuery{})
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.True(t, errors.Is(err, store.ErrNotFound))
+}

--- a/internal/api/service/evaluation.go
+++ b/internal/api/service/evaluation.go
@@ -44,7 +44,7 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 		return nil, errors.New("service: engine + templates registry are required to evaluate rules")
 	}
 
-	rule, err := s.store.GetRule(ctx, ruleID)
+	rule, err := s.getRuleForContract(ctx, ruleID)
 	if err != nil {
 		return nil, err
 	}
@@ -71,10 +71,12 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 	ended := time.Now().UTC()
 
 	evaluation := &models.Evaluation{
-		ID:        uuid.New(),
-		RuleID:    rule.ID,
-		StartedAt: started,
-		EndedAt:   ended,
+		ID:              uuid.New(),
+		ContractVersion: rule.ContractVersion.Effective(),
+		RuleID:          rule.ID,
+		StartedAt:       started,
+		EndedAt:         ended,
+		CreatedAt:       ended,
 	}
 
 	if evalErr != nil {
@@ -86,6 +88,10 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 		}
 		evaluation.Evidence = ev
 		if err := s.store.CreateEvaluation(ctx, evaluation); err != nil {
+			return nil, err
+		}
+		periodID := rule.Cadence.PeriodID(req.PIT)
+		if err := s.store.RecordCapture(ctx, captureInput(rule, evaluation, periodID, req.Trigger, req.PIT)); err != nil {
 			return nil, err
 		}
 		if _, mErr := s.openEngineErrorAlert(ctx, rule, evaluation, evalErr); mErr != nil {
@@ -107,10 +113,10 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 	// cases (see models.Cadence.PeriodID).
 	periodID := rule.Cadence.PeriodID(req.PIT)
 
-	// Plan alert transitions before recording the capture so its bounded evidence
-	// contains every failure plus the passing outcomes that will resolve active
-	// alerts. The plan and capture both use the exact outcomes evaluated above —
-	// no Ledger read is repeated and no prior alert evidence is reused.
+	// Plan alert transitions before recording the capture. The capture retains
+	// every exact outcome from this evaluation; the plan independently selects
+	// only the outcomes that need an alert mutation. No Ledger read is repeated
+	// and no prior alert evidence is reused.
 	//
 	// The idempotent ledger store has no cross-op transaction, so inTx runs the
 	// capture and planned transitions sequentially; each write is individually
@@ -122,7 +128,7 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 		}
 		plan := planAlertTransitions(outcomes, activeFingerprints)
 
-		evidence, err := marshalOutcomes(plan.evidenceOutcomes())
+		evidence, err := marshalOutcomes(outcomes)
 		if err != nil {
 			return err
 		}
@@ -131,7 +137,7 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 		if err := st.CreateEvaluation(ctx, evaluation); err != nil {
 			return err
 		}
-		if err := st.RecordCapture(ctx, captureInput(rule, evaluation, periodID, req.Trigger)); err != nil {
+		if err := st.RecordCapture(ctx, captureInput(rule, evaluation, periodID, req.Trigger, req.PIT)); err != nil {
 			return err
 		}
 		return driveAlertTransitions(ctx, st, rule, evaluation, plan, periodID, ended)
@@ -144,23 +150,32 @@ func (s *Service) EvaluateRule(ctx context.Context, ruleID uuid.UUID, req Evalua
 }
 
 // captureInput builds the immutable capture record for an evaluation (ADR-003):
-// the verdict, the bounded transition evidence the evaluation already computed,
+// the verdict, the complete outcome evidence the evaluation already computed,
 // and what triggered the run.
-func captureInput(rule *models.Rule, ev *models.Evaluation, periodID, trigger string) store.CaptureInput {
+func captureInput(rule *models.Rule, ev *models.Evaluation, periodID, trigger string, pit time.Time) store.CaptureInput {
 	verdict := "pass"
-	if ev.Result == models.EvaluationFail {
+	switch ev.Result {
+	case models.EvaluationFail:
 		verdict = "fail"
+	case models.EvaluationError:
+		verdict = "error"
 	}
 
 	return store.CaptureInput{
-		RuleID:       rule.ID,
-		TemplateKind: string(rule.TemplateKind),
-		PeriodID:     periodID,
-		EvaluationID: ev.ID,
-		CapturedAt:   ev.EndedAt,
-		Verdict:      verdict,
-		Trigger:      trigger,
-		Evidence:     ev.Evidence,
+		RuleID:          rule.ID,
+		ContractVersion: rule.ContractVersion.Effective(),
+		TemplateKind:    string(rule.TemplateKind),
+		PeriodID:        periodID,
+		EvaluationID:    ev.ID,
+		CapturedAt:      ev.EndedAt,
+		Verdict:         verdict,
+		Trigger:         trigger,
+		Evidence:        ev.Evidence,
+		RuleRevision:    rule.Revision,
+		PIT:             pit,
+		StartedAt:       ev.StartedAt,
+		Result:          ev.Result,
+		Error:           ev.Error,
 	}
 }
 
@@ -233,17 +248,6 @@ func planAlertTransitions(outcomes []templates.Outcome, activeFingerprints []str
 	return plan
 }
 
-// evidenceOutcomes returns the bounded capture roster: every failure and only
-// those passes that are planned to resolve an active alert. The original
-// outcome values are retained verbatim from the evaluation.
-func (p alertTransitionPlan) evidenceOutcomes() []templates.Outcome {
-	outcomes := make([]templates.Outcome, 0, len(p.outcomeTransitions))
-	for _, transition := range p.outcomeTransitions {
-		outcomes = append(outcomes, transition.outcome)
-	}
-	return outcomes
-}
-
 // driveAlertTransitions applies the precomputed plan after the capture is
 // recorded. Open/update, auto-resolution, disappearance sweeping, and their
 // idempotency semantics remain owned by the store.
@@ -270,14 +274,15 @@ func driveAlertTransitions(
 			return fmt.Errorf("marshal evidence for %s: %w", outcome.Fingerprint, err)
 		}
 		_, err = st.OpenOrUpdateAlert(ctx, store.OpenAlertInput{
-			RuleID:       rule.ID,
-			Fingerprint:  outcome.Fingerprint,
-			PeriodID:     periodID,
-			Severity:     rule.Severity,
-			EvaluationID: evaluation.ID,
-			Evidence:     evidenceJSON,
-			Labels:       rule.Labels,
-			OccurredAt:   ended,
+			RuleID:          rule.ID,
+			ContractVersion: rule.ContractVersion.Effective(),
+			Fingerprint:     outcome.Fingerprint,
+			PeriodID:        periodID,
+			Severity:        rule.Severity,
+			EvaluationID:    evaluation.ID,
+			Evidence:        evidenceJSON,
+			Labels:          rule.Labels,
+			OccurredAt:      ended,
 		})
 		if err != nil {
 			return fmt.Errorf("open/update alert for %s: %w", outcome.Fingerprint, err)
@@ -314,8 +319,9 @@ func (s *Service) openEngineErrorAlert(ctx context.Context, rule *models.Rule, e
 	}
 
 	res, err := s.store.OpenOrUpdateAlert(ctx, store.OpenAlertInput{
-		RuleID:      rule.ID,
-		Fingerprint: engineErrorFingerprint,
+		RuleID:          rule.ID,
+		ContractVersion: rule.ContractVersion.Effective(),
+		Fingerprint:     engineErrorFingerprint,
 		// Engine-health is operational, not a per-period reconciliation fact:
 		// a resolver timeout means "the check couldn't run", not "March didn't
 		// reconcile". Keep it in the continuous scope regardless of cadence.

--- a/internal/api/service/evaluation_evidence_test.go
+++ b/internal/api/service/evaluation_evidence_test.go
@@ -113,14 +113,14 @@ func TestEvaluateRule_RetainsFreshSuccessfulResolutionEvidence(t *testing.T) {
 	require.Equal(t, models.AlertResolved, fakeStore.alertFor(rule.ID, "asset:USD/2").Status)
 	require.Len(t, fakeStore.eventsFor(alertID), 2)
 
-	// A later successful evaluation sees no active transition to document. It
-	// records an empty evidence roster and does not create another pass event.
+	// A later successful evaluation sees no active transition to document. Its
+	// observation is still retained even though it creates no alert event.
 	retryEvaluation, err := svc.EvaluateRule(ctx, rule.ID, EvaluateRuleRequest{PIT: time.Now()})
 	require.NoError(t, err)
 	require.Equal(t, models.EvaluationPass, retryEvaluation.Result)
 	require.Len(t, fakeStore.captures, 3)
-	require.Empty(t, decodeRetainedOutcomes(t, fakeStore.captures[2].Evidence))
-	require.JSONEq(t, `[]`, string(retryEvaluation.Evidence))
+	require.Len(t, decodeRetainedOutcomes(t, fakeStore.captures[2].Evidence), 1)
+	require.JSONEq(t, string(passingEvaluation.Evidence), string(retryEvaluation.Evidence))
 	require.Len(t, fakeStore.eventsFor(alertID), 2)
 }
 
@@ -145,10 +145,10 @@ func TestEvaluateRule_MixedFailureAndSuccessfulResolutionEvidence(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, models.EvaluationFail, first.Result)
 	firstEvidence := retainedOutcomesByFingerprint(t, fakeStore.captures[0].Evidence)
-	require.Len(t, firstEvidence, 2)
+	require.Len(t, firstEvidence, 3)
 	require.Contains(t, firstEvidence, "asset:USD/2")
 	require.Contains(t, firstEvidence, "asset:EUR/2")
-	require.NotContains(t, firstEvidence, "asset:GBP/2", "unrelated passes must not be retained")
+	require.True(t, firstEvidence["asset:GBP/2"].Passed)
 
 	// USD now reconciles, EUR remains broken with a new observed value, and GBP
 	// remains an unrelated pass. The overall verdict stays FAIL.
@@ -160,14 +160,14 @@ func TestEvaluateRule_MixedFailureAndSuccessfulResolutionEvidence(t *testing.T) 
 	require.Len(t, fakeStore.captures, 2)
 
 	mixed := retainedOutcomesByFingerprint(t, fakeStore.captures[1].Evidence)
-	require.Len(t, mixed, 2)
+	require.Len(t, mixed, 3)
 	require.True(t, mixed["asset:USD/2"].Passed)
 	require.Equal(t, "350", mixed["asset:USD/2"].Evidence.RightBalance)
 	require.Equal(t, "0", mixed["asset:USD/2"].Evidence.Difference)
 	require.False(t, mixed["asset:EUR/2"].Passed)
 	require.Equal(t, "60", mixed["asset:EUR/2"].Evidence.RightBalance)
 	require.Equal(t, "30", mixed["asset:EUR/2"].Evidence.Difference)
-	require.NotContains(t, mixed, "asset:GBP/2")
+	require.True(t, mixed["asset:GBP/2"].Passed)
 	require.Nil(t, fakeStore.activeFor(rule.ID, "asset:USD/2"))
 	require.NotNil(t, fakeStore.activeFor(rule.ID, "asset:EUR/2"))
 }

--- a/internal/api/service/rule.go
+++ b/internal/api/service/rule.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
+	"github.com/formancehq/reconciliation/internal/contractversion"
 	"github.com/formancehq/reconciliation/internal/engine"
 	"github.com/formancehq/reconciliation/internal/ledger"
 	"github.com/formancehq/reconciliation/internal/models"
@@ -116,10 +118,14 @@ func (s *Service) CreateRule(ctx context.Context, req *CreateRuleRequest) (*mode
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("%w: %v", templates.ErrInvalidSpec, err)
 	}
+	contractVersion := createContractVersion(ctx)
 
 	ev, err := s.templates.Get(req.TemplateKind)
 	if err != nil {
 		return nil, err
+	}
+	if err := validateTemplateContract(contractVersion, req.TemplateKind); err != nil {
+		return nil, fmt.Errorf("%w: %v", templates.ErrInvalidSpec, err)
 	}
 	if err := ev.Validate(req.TemplateSpec); err != nil {
 		return nil, err
@@ -154,18 +160,21 @@ func (s *Service) CreateRule(ctx context.Context, req *CreateRuleRequest) (*mode
 	}
 
 	rule := &models.Rule{
-		ID:            uuid.New(),
-		Name:          req.Name,
-		TemplateKind:  req.TemplateKind,
-		TemplateSpec:  req.TemplateSpec,
-		CompiledCEL:   compiled,
-		Enabled:       enabled,
-		Severity:      severity,
-		Cadence:       cadence,
-		Schedule:      req.Schedule,
-		Notifications: req.Notifications,
-		Labels:        req.Labels,
+		ID:              uuid.New(),
+		ContractVersion: contractVersion,
+		Name:            req.Name,
+		TemplateKind:    req.TemplateKind,
+		TemplateSpec:    req.TemplateSpec,
+		CompiledCEL:     compiled,
+		Enabled:         enabled,
+		Severity:        severity,
+		Cadence:         cadence,
+		Schedule:        req.Schedule,
+		Notifications:   req.Notifications,
+		Labels:          req.Labels,
+		CreatedAt:       time.Now().UTC(),
 	}
+	rule.UpdatedAt = rule.CreatedAt
 	if err := s.store.CreateRule(ctx, rule); err != nil {
 		return nil, err
 	}
@@ -174,26 +183,29 @@ func (s *Service) CreateRule(ctx context.Context, req *CreateRuleRequest) (*mode
 
 // GetRule returns one rule or store.ErrNotFound.
 func (s *Service) GetRule(ctx context.Context, id uuid.UUID) (*models.Rule, error) {
-	return s.store.GetRule(ctx, id)
+	return s.getRuleForContract(ctx, id)
 }
 
 // ListRules is a passthrough — the storage layer handles pagination + filters.
 func (s *Service) ListRules(ctx context.Context, q store.GetRulesQuery) (*bunpaginate.Cursor[models.Rule], error) {
+	if version, ok := contractversion.FromContext(ctx); ok {
+		q.Options.Options.ContractVersion = &version
+	}
 	return s.store.ListRules(ctx, q)
 }
 
 // PatchRule applies a partial update. If templateKind or templateSpec changes,
 // the new spec is validated and the compiled_cel is rederived.
 func (s *Service) PatchRule(ctx context.Context, id uuid.UUID, patch store.RulePatch) error {
+	rule, err := s.getRuleForContract(ctx, id)
+	if err != nil {
+		return err
+	}
 	// If the caller is changing the template surface, re-validate against the
 	// registry and rederive compiled_cel so explanations stay accurate.
 	if patch.TemplateKind != nil || patch.TemplateSpec != nil {
 		if s.templates == nil {
 			return errors.New("service: templates registry not configured")
-		}
-		rule, err := s.store.GetRule(ctx, id)
-		if err != nil {
-			return err
 		}
 		kind := rule.TemplateKind
 		if patch.TemplateKind != nil {
@@ -206,6 +218,9 @@ func (s *Service) PatchRule(ctx context.Context, id uuid.UUID, patch store.RuleP
 		ev, err := s.templates.Get(kind)
 		if err != nil {
 			return err
+		}
+		if err := validateTemplateContract(rule.ContractVersion, kind); err != nil {
+			return fmt.Errorf("%w: %v", templates.ErrInvalidSpec, err)
 		}
 		if err := ev.Validate(spec); err != nil {
 			return err
@@ -229,6 +244,9 @@ func (s *Service) PatchRule(ctx context.Context, id uuid.UUID, patch store.RuleP
 
 // DeleteRule cascades to evaluations + alerts (and their events) via FK.
 func (s *Service) DeleteRule(ctx context.Context, id uuid.UUID) error {
+	if _, err := s.getRuleForContract(ctx, id); err != nil {
+		return err
+	}
 	return s.store.DeleteRule(ctx, id)
 }
 

--- a/internal/api/service/service.go
+++ b/internal/api/service/service.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
 
+	"github.com/formancehq/reconciliation/internal/contractversion"
 	"github.com/formancehq/reconciliation/internal/engine"
 	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/store"
@@ -56,6 +58,21 @@ type Store interface {
 	GetAlert(ctx context.Context, id uuid.UUID) (*models.Alert, error)
 	ListAlerts(ctx context.Context, q store.GetAlertsQuery) (*bunpaginate.Cursor[models.Alert], error)
 	ListAlertEvents(ctx context.Context, alertID uuid.UUID, q store.GetAlertEventsQuery) (*bunpaginate.Cursor[models.AlertEvent], error)
+}
+
+type ruleActivityStore interface {
+	ListRuleActivities(context.Context, uuid.UUID, store.GetRuleActivitiesQuery) (*bunpaginate.Cursor[models.RuleActivity], error)
+}
+
+func (s *Service) ListRuleActivities(ctx context.Context, ruleID uuid.UUID, q store.GetRuleActivitiesQuery) (*bunpaginate.Cursor[models.RuleActivity], error) {
+	activityStore, ok := s.store.(ruleActivityStore)
+	if !ok {
+		return nil, errors.New("rule activity history is not supported by this store")
+	}
+	if version, ok := contractversion.FromContext(ctx); ok {
+		q.Options.Options.ContractVersion = &version
+	}
+	return activityStore.ListRuleActivities(ctx, ruleID, q)
 }
 
 // Service is the orchestrator for the V1 rule/evaluation/alert surface.

--- a/internal/api/service/v1_orchestration_test.go
+++ b/internal/api/service/v1_orchestration_test.go
@@ -560,11 +560,11 @@ func TestEvaluate_PassNoAlerts(t *testing.T) {
 	if len(store.alerts) != 0 {
 		t.Errorf("expected no alerts, got %d", len(store.alerts))
 	}
-	if string(ev.Evidence) != "[]" {
-		t.Errorf("expected empty evaluation evidence, got %s", ev.Evidence)
+	if string(ev.Evidence) == "[]" {
+		t.Errorf("expected complete successful evaluation evidence, got %s", ev.Evidence)
 	}
-	if len(store.captures) != 1 || string(store.captures[0].Evidence) != "[]" {
-		t.Errorf("expected one capture with empty evidence, got %+v", store.captures)
+	if len(store.captures) != 1 || string(store.captures[0].Evidence) != string(ev.Evidence) {
+		t.Errorf("expected one capture with complete evidence, got %+v", store.captures)
 	}
 }
 
@@ -732,6 +732,9 @@ func TestEvaluate_EngineError_RaisesMetaAlert(t *testing.T) {
 	}
 	if ev.Error == "" {
 		t.Errorf("expected non-empty Error on evaluation row")
+	}
+	if len(store.captures) != 1 || store.captures[0].Verdict != "error" {
+		t.Fatalf("expected one durable error capture, got %+v", store.captures)
 	}
 
 	if got := len(store.alerts); got != 1 {

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -73,3 +73,11 @@ func getPaginatedQueryOptionsCaptures(r *http.Request) (*store.PaginatedQueryOpt
 		Period: r.URL.Query().Get("period"),
 	}).WithPageSize(pageSize)), nil
 }
+
+func getPaginatedQueryOptionsRuleActivities(r *http.Request) (*store.PaginatedQueryOptions[store.RuleActivitiesFilters], error) {
+	pageSize, err := getPageSize(r)
+	if err != nil {
+		return nil, err
+	}
+	return pointer.For(store.NewPaginatedQueryOptions(store.RuleActivitiesFilters{}).WithPageSize(pageSize)), nil
+}

--- a/internal/contractversion/context.go
+++ b/internal/contractversion/context.go
@@ -1,0 +1,18 @@
+package contractversion
+
+import (
+	"context"
+
+	"github.com/formancehq/reconciliation/internal/models"
+)
+
+type contextKey struct{}
+
+func WithContext(ctx context.Context, version models.ContractVersion) context.Context {
+	return context.WithValue(ctx, contextKey{}, version)
+}
+
+func FromContext(ctx context.Context) (models.ContractVersion, bool) {
+	version, ok := ctx.Value(contextKey{}).(models.ContractVersion)
+	return version, ok
+}

--- a/internal/engine/budget.go
+++ b/internal/engine/budget.go
@@ -56,8 +56,8 @@ func mergeLimits(override, defaults Limits) Limits {
 // budgetTracker is the per-evaluation accumulator. Resolvers call its methods
 // before doing work; the engine reads .Cost() into the persisted evaluation row.
 type budgetTracker struct {
-	limits           Limits
-	accountsScanned  atomic.Int64
+	limits          Limits
+	accountsScanned atomic.Int64
 }
 
 func newBudgetTracker(limits Limits) *budgetTracker {
@@ -76,6 +76,16 @@ func (b *budgetTracker) ChargeAccounts(n int) error {
 		return fmt.Errorf("evaluation budget exceeded: scanned %d accounts (limit %d)", total, b.limits.MaxAccountsScanned)
 	}
 	return nil
+}
+
+// RemainingAccounts returns the number of accounts another resolver call may
+// scan without exceeding the shared per-evaluation limit.
+func (b *budgetTracker) RemainingAccounts() int {
+	remaining := b.limits.MaxAccountsScanned - int(b.accountsScanned.Load())
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 // AccountsScanned returns the running total — used to populate

--- a/internal/engine/builtins.go
+++ b/internal/engine/builtins.go
@@ -48,8 +48,10 @@ func (e *evalCtx) keyFor(kind SourceKind) string {
 // expressions at rule-create time without exercising any resolvers.
 func declarations() []cel.EnvOption {
 	srcT := celSourceType
+	exactBalanceT := celExactBalanceType
 	intMap := types.NewMapType(types.StringType, types.IntType)
 	intList := types.NewListType(types.IntType)
+	exactBalanceList := types.NewListType(exactBalanceT)
 
 	return []cel.EnvOption{
 		cel.Function("ledgerSet",
@@ -74,6 +76,26 @@ func declarations() []cel.EnvOption {
 		cel.Function("abs",
 			cel.Overload("abs_int", []*cel.Type{cel.IntType}, cel.IntType),
 		),
+		cel.Function("exactBalance",
+			cel.Overload("exactBalance_source_string_string",
+				[]*cel.Type{srcT, cel.StringType, cel.StringType}, exactBalanceT),
+		),
+		cel.Function("balanceEquation",
+			cel.Overload("balanceEquation_list_list_string",
+				[]*cel.Type{exactBalanceList, intList, cel.StringType}, cel.BoolType),
+		),
+		cel.Function("exchangeRateWithin",
+			cel.Overload("exchangeRateWithin_balance_balance_string_string",
+				[]*cel.Type{exactBalanceT, exactBalanceT, cel.StringType, cel.StringType}, cel.BoolType),
+		),
+		cel.Function("sourceConsensus",
+			cel.Overload("sourceConsensus_list_string",
+				[]*cel.Type{exactBalanceList, cel.StringType}, cel.BoolType),
+		),
+		cel.Function("coverageRatioWithin",
+			cel.Overload("coverageRatioWithin_list_list_list_list_string_string",
+				[]*cel.Type{exactBalanceList, intList, exactBalanceList, intList, cel.StringType, cel.StringType}, cel.BoolType),
+		),
 	}
 }
 
@@ -81,8 +103,10 @@ func declarations() []cel.EnvOption {
 // runtime closures over the supplied evalCtx. Built fresh per Evaluate call.
 func bindings(e *evalCtx) []cel.EnvOption {
 	srcT := celSourceType
+	exactBalanceT := celExactBalanceType
 	intMap := types.NewMapType(types.StringType, types.IntType)
 	intList := types.NewListType(types.IntType)
+	exactBalanceList := types.NewListType(exactBalanceT)
 
 	return []cel.EnvOption{
 		cel.Function("ledgerSet",
@@ -158,6 +182,31 @@ func bindings(e *evalCtx) []cel.EnvOption {
 					return types.Int(i)
 				}),
 			),
+		),
+		cel.Function("exactBalance",
+			cel.Overload("exactBalance_source_string_string",
+				[]*cel.Type{srcT, cel.StringType, cel.StringType}, exactBalanceT,
+				cel.FunctionBinding(e.makeExactBalance)),
+		),
+		cel.Function("balanceEquation",
+			cel.Overload("balanceEquation_list_list_string",
+				[]*cel.Type{exactBalanceList, intList, cel.StringType}, cel.BoolType,
+				cel.FunctionBinding(e.balanceEquation)),
+		),
+		cel.Function("exchangeRateWithin",
+			cel.Overload("exchangeRateWithin_balance_balance_string_string",
+				[]*cel.Type{exactBalanceT, exactBalanceT, cel.StringType, cel.StringType}, cel.BoolType,
+				cel.FunctionBinding(e.exchangeRateWithin)),
+		),
+		cel.Function("sourceConsensus",
+			cel.Overload("sourceConsensus_list_string",
+				[]*cel.Type{exactBalanceList, cel.StringType}, cel.BoolType,
+				cel.FunctionBinding(e.sourceConsensus)),
+		),
+		cel.Function("coverageRatioWithin",
+			cel.Overload("coverageRatioWithin_list_list_list_list_string_string",
+				[]*cel.Type{exactBalanceList, intList, exactBalanceList, intList, cel.StringType, cel.StringType}, cel.BoolType,
+				cel.FunctionBinding(e.coverageRatioWithin)),
 		),
 	}
 }

--- a/internal/engine/builtins.go
+++ b/internal/engine/builtins.go
@@ -321,7 +321,7 @@ func (e *evalCtx) metadataIntSum(src, key ref.Val) ref.Val {
 	if e.resolvers.Ledger == nil {
 		return types.NewErr("metadataInt: ledger resolver not configured")
 	}
-	accts, err := e.resolvers.Ledger.ListAccounts(e.ctx, s.Ledger, s.Query, e.budget.limits.MaxAccountsScanned)
+	accts, err := e.listAccounts(s)
 	if err != nil {
 		return types.NewErr("metadataInt(%s): %v", k, err)
 	}
@@ -330,6 +330,17 @@ func (e *evalCtx) metadataIntSum(src, key ref.Val) ref.Val {
 		return types.NewErr("metadataInt(%s): %v", k, err)
 	}
 	return bigIntToInt(total)
+}
+
+func (e *evalCtx) listAccounts(source *Source) ([]Account, error) {
+	accounts, err := e.resolvers.Ledger.ListAccounts(e.ctx, source.Ledger, source.Query, e.budget.RemainingAccounts())
+	if err != nil {
+		return nil, err
+	}
+	if err := e.budget.ChargeAccounts(len(accounts)); err != nil {
+		return nil, err
+	}
+	return accounts, nil
 }
 
 // SumAccountMetadataInt sums the base-10 integer metadata field `key` across the

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -134,7 +134,7 @@ func (e *evalCtx) exchangeRateWithin(args ...ref.Val) ref.Val {
 	if !ok {
 		return types.NewErr("exchangeRateWithin: quote must be ExactBalance")
 	}
-	min, err := exactPositiveDecimal(args[2])
+	min, err := exactNonNegativeDecimal(args[2])
 	if err != nil {
 		return types.NewErr("exchangeRateWithin: min: %v", err)
 	}
@@ -212,7 +212,7 @@ func (e *evalCtx) coverageRatioWithin(args ...ref.Val) ref.Val {
 	if denominator.Sign() == 0 {
 		return types.False
 	}
-	minimum, err := exactPositiveDecimal(args[4])
+	minimum, err := exactNonNegativeDecimal(args[4])
 	if err != nil {
 		return types.NewErr("coverageRatioWithin: min: %v", err)
 	}
@@ -303,13 +303,24 @@ func exactNonNegativeInteger(value ref.Val) (*big.Int, error) {
 }
 
 func exactPositiveDecimal(value ref.Val) (*big.Rat, error) {
+	r, err := exactNonNegativeDecimal(value)
+	if err != nil {
+		return nil, err
+	}
+	if r.Sign() == 0 {
+		return nil, fmt.Errorf("must be greater than zero")
+	}
+	return r, nil
+}
+
+func exactNonNegativeDecimal(value ref.Val) (*big.Rat, error) {
 	text, ok := value.Value().(string)
 	if !ok || len(text) > 78 || !exactDecimalPattern.MatchString(text) {
 		return nil, fmt.Errorf("must be a plain decimal string")
 	}
 	r, ok := new(big.Rat).SetString(text)
-	if !ok || r.Sign() <= 0 {
-		return nil, fmt.Errorf("must be greater than zero")
+	if !ok || r.Sign() < 0 {
+		return nil, fmt.Errorf("must be greater than or equal to zero")
 	}
 	return r, nil
 }

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -75,7 +75,7 @@ func (e *evalCtx) resolveExactBalanceWithPresence(balance *ExactBalance) (*big.I
 			return nil, false, err
 		}
 		value, err := SumAccountMetadataInt(accounts, balance.MetadataKey)
-		return value, true, err
+		return value, len(accounts) > 0, err
 	}
 	balances, err := e.resolveBalances(balance.Source)
 	if err != nil {

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -146,6 +146,9 @@ func (e *evalCtx) exchangeRateWithin(args ...ref.Val) ref.Val {
 	if err != nil {
 		return types.NewErr("exchangeRateWithin: resolve base: %v", err)
 	}
+	// Resolve both inputs before applying the undefined-base verdict. The direct
+	// template resolves its full source set first, so later data errors must not
+	// disappear when the stored CEL is replayed.
 	quoteValue, err := e.resolveExactBalance(quote)
 	if err != nil {
 		return types.NewErr("exchangeRateWithin: resolve quote: %v", err)
@@ -177,6 +180,9 @@ func (e *evalCtx) sourceConsensus(args ...ref.Val) ref.Val {
 	}
 
 	var minimum, maximum *big.Int
+	// Missing is a business verdict, not a reason to skip remaining reads. Keep
+	// resolving so a later malformed or over-budget source has the same error
+	// semantics as the direct template path.
 	missing := false
 	for i, balance := range balances {
 		value, present, resolveErr := e.resolveExactBalanceWithPresence(balance)

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -1,0 +1,327 @@
+package engine
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// ExactBalance is an opaque CEL value that defers a scalar balance read until
+// an exact-arithmetic predicate evaluates it. It avoids converting ledger
+// volumes through CEL's int64 or double types.
+type ExactBalance struct {
+	Source      *Source
+	Asset       string
+	MetadataKey string
+}
+
+var celExactBalanceType = types.NewOpaqueType("formance.engine.ExactBalance")
+
+func (b *ExactBalance) ConvertToNative(reflect.Type) (any, error) { return b, nil }
+func (b *ExactBalance) ConvertToType(typeVal ref.Type) ref.Val {
+	if typeVal == celExactBalanceType {
+		return b
+	}
+	return types.NewErr("type conversion not allowed: %s -> %s", celExactBalanceType, typeVal)
+}
+func (b *ExactBalance) Equal(other ref.Val) ref.Val {
+	o, ok := other.(*ExactBalance)
+	if !ok {
+		return types.False
+	}
+	return types.Bool(b.Asset == o.Asset && b.MetadataKey == o.MetadataKey && b.Source.Equal(o.Source) == types.True)
+}
+func (b *ExactBalance) Type() ref.Type { return celExactBalanceType }
+func (b *ExactBalance) Value() any     { return b }
+
+func (e *evalCtx) makeExactBalance(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("exactBalance: expected 3 arguments")
+	}
+	source, ok := args[0].Value().(*Source)
+	if !ok {
+		return types.NewErr("exactBalance: source must be Source, got %T", args[0].Value())
+	}
+	asset, ok := args[1].Value().(string)
+	if !ok {
+		return types.NewErr("exactBalance: asset must be string, got %T", args[1].Value())
+	}
+	metadataKey, ok := args[2].Value().(string)
+	if !ok {
+		return types.NewErr("exactBalance: metadata key must be string, got %T", args[2].Value())
+	}
+	return &ExactBalance{Source: source, Asset: asset, MetadataKey: metadataKey}
+}
+
+func (e *evalCtx) resolveExactBalance(balance *ExactBalance) (*big.Int, error) {
+	value, _, err := e.resolveExactBalanceWithPresence(balance)
+	return value, err
+}
+
+func (e *evalCtx) resolveExactBalanceWithPresence(balance *ExactBalance) (*big.Int, bool, error) {
+	if balance.MetadataKey != "" {
+		if e.resolvers.Ledger == nil {
+			return nil, false, fmt.Errorf("ledger resolver not configured")
+		}
+		accounts, err := e.resolvers.Ledger.ListAccounts(e.ctx, balance.Source.Ledger, balance.Source.Query, e.budget.limits.MaxAccountsScanned)
+		if err != nil {
+			return nil, false, err
+		}
+		value, err := SumAccountMetadataInt(accounts, balance.MetadataKey)
+		return value, true, err
+	}
+	balances, err := e.resolveBalances(balance.Source)
+	if err != nil {
+		return nil, false, err
+	}
+	value, present := balances[balance.Asset]
+	if !present || value == nil {
+		return new(big.Int), false, nil
+	}
+	return new(big.Int).Set(value), true, nil
+}
+
+func (e *evalCtx) balanceEquation(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("balanceEquation: expected 3 arguments")
+	}
+	balances, err := exactBalanceList(args[0])
+	if err != nil {
+		return types.NewErr("balanceEquation: %v", err)
+	}
+	coefficients, err := intList(args[1])
+	if err != nil {
+		return types.NewErr("balanceEquation: %v", err)
+	}
+	if len(balances) != len(coefficients) {
+		return types.NewErr("balanceEquation: balances and coefficients have different lengths")
+	}
+	toleranceText, ok := args[2].Value().(string)
+	if !ok || len(toleranceText) > 78 || !exactIntegerPattern.MatchString(toleranceText) {
+		return types.NewErr("balanceEquation: tolerance must be a non-negative integer string of at most 78 digits")
+	}
+	tolerance, ok := new(big.Int).SetString(toleranceText, 10)
+	if !ok || tolerance.Sign() < 0 {
+		return types.NewErr("balanceEquation: invalid tolerance %q", toleranceText)
+	}
+	residual := new(big.Int)
+	for i, balance := range balances {
+		value, resolveErr := e.resolveExactBalance(balance)
+		if resolveErr != nil {
+			return types.NewErr("balanceEquation: resolve source %d: %v", i, resolveErr)
+		}
+		residual.Add(residual, new(big.Int).Mul(value, big.NewInt(coefficients[i])))
+	}
+	return types.Bool(new(big.Int).Abs(residual).Cmp(tolerance) <= 0)
+}
+
+func (e *evalCtx) exchangeRateWithin(args ...ref.Val) ref.Val {
+	if len(args) != 4 {
+		return types.NewErr("exchangeRateWithin: expected 4 arguments")
+	}
+	base, ok := args[0].Value().(*ExactBalance)
+	if !ok {
+		return types.NewErr("exchangeRateWithin: base must be ExactBalance")
+	}
+	quote, ok := args[1].Value().(*ExactBalance)
+	if !ok {
+		return types.NewErr("exchangeRateWithin: quote must be ExactBalance")
+	}
+	min, err := exactPositiveDecimal(args[2])
+	if err != nil {
+		return types.NewErr("exchangeRateWithin: min: %v", err)
+	}
+	max, err := exactPositiveDecimal(args[3])
+	if err != nil {
+		return types.NewErr("exchangeRateWithin: max: %v", err)
+	}
+	baseValue, err := e.resolveExactBalance(base)
+	if err != nil {
+		return types.NewErr("exchangeRateWithin: resolve base: %v", err)
+	}
+	if baseValue.Sign() == 0 {
+		return types.False
+	}
+	quoteValue, err := e.resolveExactBalance(quote)
+	if err != nil {
+		return types.NewErr("exchangeRateWithin: resolve quote: %v", err)
+	}
+	observed := new(big.Rat).SetFrac(
+		new(big.Int).Mul(quoteValue, exactPow10(exactAssetPrecision(base.Asset))),
+		new(big.Int).Mul(baseValue, exactPow10(exactAssetPrecision(quote.Asset))),
+	)
+	return types.Bool(observed.Cmp(min) >= 0 && observed.Cmp(max) <= 0)
+}
+
+func (e *evalCtx) sourceConsensus(args ...ref.Val) ref.Val {
+	if len(args) != 2 {
+		return types.NewErr("sourceConsensus: expected 2 arguments")
+	}
+	balances, err := exactBalanceList(args[0])
+	if err != nil {
+		return types.NewErr("sourceConsensus: %v", err)
+	}
+	if len(balances) < 2 {
+		return types.NewErr("sourceConsensus: expected at least two balances")
+	}
+	tolerance, err := exactNonNegativeInteger(args[1])
+	if err != nil {
+		return types.NewErr("sourceConsensus: tolerance: %v", err)
+	}
+
+	var minimum, maximum *big.Int
+	for i, balance := range balances {
+		value, present, resolveErr := e.resolveExactBalanceWithPresence(balance)
+		if resolveErr != nil {
+			return types.NewErr("sourceConsensus: resolve source %d: %v", i, resolveErr)
+		}
+		if !present {
+			return types.False
+		}
+		if minimum == nil || value.Cmp(minimum) < 0 {
+			minimum = new(big.Int).Set(value)
+		}
+		if maximum == nil || value.Cmp(maximum) > 0 {
+			maximum = new(big.Int).Set(value)
+		}
+	}
+
+	spread := new(big.Int).Sub(maximum, minimum)
+	return types.Bool(spread.Cmp(tolerance) <= 0)
+}
+
+func (e *evalCtx) coverageRatioWithin(args ...ref.Val) ref.Val {
+	if len(args) != 6 {
+		return types.NewErr("coverageRatioWithin: expected 6 arguments")
+	}
+	numerator, err := e.weightedExactTotal(args[0], args[1], "numerator")
+	if err != nil {
+		return types.NewErr("coverageRatioWithin: %v", err)
+	}
+	denominator, err := e.weightedExactTotal(args[2], args[3], "denominator")
+	if err != nil {
+		return types.NewErr("coverageRatioWithin: %v", err)
+	}
+	if denominator.Sign() == 0 {
+		return types.False
+	}
+	minimum, err := exactPositiveDecimal(args[4])
+	if err != nil {
+		return types.NewErr("coverageRatioWithin: min: %v", err)
+	}
+	maximum, err := exactPositiveDecimal(args[5])
+	if err != nil {
+		return types.NewErr("coverageRatioWithin: max: %v", err)
+	}
+	observed := new(big.Rat).SetFrac(numerator, denominator)
+	return types.Bool(observed.Cmp(minimum) >= 0 && observed.Cmp(maximum) <= 0)
+}
+
+func (e *evalCtx) weightedExactTotal(balanceValue, coefficientValue ref.Val, label string) (*big.Int, error) {
+	balances, err := exactBalanceList(balanceValue)
+	if err != nil {
+		return nil, fmt.Errorf("%s balances: %w", label, err)
+	}
+	coefficients, err := intList(coefficientValue)
+	if err != nil {
+		return nil, fmt.Errorf("%s coefficients: %w", label, err)
+	}
+	if len(balances) != len(coefficients) {
+		return nil, fmt.Errorf("%s balances and coefficients have different lengths", label)
+	}
+	total := new(big.Int)
+	for i, balance := range balances {
+		value, resolveErr := e.resolveExactBalance(balance)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("resolve %s source %d: %w", label, i, resolveErr)
+		}
+		total.Add(total, new(big.Int).Mul(value, big.NewInt(coefficients[i])))
+	}
+	return total, nil
+}
+
+func exactBalanceList(value ref.Val) ([]*ExactBalance, error) {
+	lister, ok := value.(traits.Lister)
+	if !ok {
+		return nil, fmt.Errorf("expected list, got %T", value)
+	}
+	size, ok := lister.Size().Value().(int64)
+	if !ok {
+		return nil, fmt.Errorf("invalid list size")
+	}
+	out := make([]*ExactBalance, 0, size)
+	for i := int64(0); i < size; i++ {
+		item, ok := lister.Get(types.Int(i)).Value().(*ExactBalance)
+		if !ok {
+			return nil, fmt.Errorf("element %d is not ExactBalance", i)
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func intList(value ref.Val) ([]int64, error) {
+	lister, ok := value.(traits.Lister)
+	if !ok {
+		return nil, fmt.Errorf("expected list, got %T", value)
+	}
+	size, ok := lister.Size().Value().(int64)
+	if !ok {
+		return nil, fmt.Errorf("invalid list size")
+	}
+	out := make([]int64, 0, size)
+	for i := int64(0); i < size; i++ {
+		item, ok := lister.Get(types.Int(i)).Value().(int64)
+		if !ok {
+			return nil, fmt.Errorf("element %d is not int", i)
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+var exactDecimalPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)(\.[0-9]+)?$`)
+var exactIntegerPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+
+func exactNonNegativeInteger(value ref.Val) (*big.Int, error) {
+	text, ok := value.Value().(string)
+	if !ok || len(text) > 78 || !exactIntegerPattern.MatchString(text) {
+		return nil, fmt.Errorf("must be a non-negative integer string of at most 78 digits")
+	}
+	integer, ok := new(big.Int).SetString(text, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid integer %q", text)
+	}
+	return integer, nil
+}
+
+func exactPositiveDecimal(value ref.Val) (*big.Rat, error) {
+	text, ok := value.Value().(string)
+	if !ok || len(text) > 78 || !exactDecimalPattern.MatchString(text) {
+		return nil, fmt.Errorf("must be a plain decimal string")
+	}
+	r, ok := new(big.Rat).SetString(text)
+	if !ok || r.Sign() <= 0 {
+		return nil, fmt.Errorf("must be greater than zero")
+	}
+	return r, nil
+}
+
+func exactAssetPrecision(asset string) int {
+	if slash := strings.LastIndexByte(asset, '/'); slash >= 0 {
+		precision, _ := strconv.Atoi(asset[slash+1:])
+		return precision
+	}
+	return 0
+}
+
+func exactPow10(precision int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+}

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -290,6 +290,12 @@ func intList(value ref.Val) ([]int64, error) {
 var exactDecimalPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)(\.[0-9]+)?$`)
 var exactIntegerPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
 
+// Valid V2 rate targets are at most 78 characters. Applying a basis-point
+// factor can add one integer digit and up to four fractional digits; the
+// template renderer retains up to 22 fractional digits. Keep enough room for
+// every valid derived bound while still rejecting unbounded power-mode input.
+const maxExactDecimalLength = 128
+
 func exactNonNegativeInteger(value ref.Val) (*big.Int, error) {
 	text, ok := value.Value().(string)
 	if !ok || len(text) > 78 || !exactIntegerPattern.MatchString(text) {
@@ -315,7 +321,7 @@ func exactPositiveDecimal(value ref.Val) (*big.Rat, error) {
 
 func exactNonNegativeDecimal(value ref.Val) (*big.Rat, error) {
 	text, ok := value.Value().(string)
-	if !ok || len(text) > 78 || !exactDecimalPattern.MatchString(text) {
+	if !ok || len(text) > maxExactDecimalLength || !exactDecimalPattern.MatchString(text) {
 		return nil, fmt.Errorf("must be a plain decimal string")
 	}
 	r, ok := new(big.Rat).SetString(text)

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -70,7 +70,7 @@ func (e *evalCtx) resolveExactBalanceWithPresence(balance *ExactBalance) (*big.I
 		if e.resolvers.Ledger == nil {
 			return nil, false, fmt.Errorf("ledger resolver not configured")
 		}
-		accounts, err := e.resolvers.Ledger.ListAccounts(e.ctx, balance.Source.Ledger, balance.Source.Query, e.budget.limits.MaxAccountsScanned)
+		accounts, err := e.listAccounts(balance.Source)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/engine/exact_balance.go
+++ b/internal/engine/exact_balance.go
@@ -146,12 +146,12 @@ func (e *evalCtx) exchangeRateWithin(args ...ref.Val) ref.Val {
 	if err != nil {
 		return types.NewErr("exchangeRateWithin: resolve base: %v", err)
 	}
-	if baseValue.Sign() == 0 {
-		return types.False
-	}
 	quoteValue, err := e.resolveExactBalance(quote)
 	if err != nil {
 		return types.NewErr("exchangeRateWithin: resolve quote: %v", err)
+	}
+	if baseValue.Sign() == 0 {
+		return types.False
 	}
 	observed := new(big.Rat).SetFrac(
 		new(big.Int).Mul(quoteValue, exactPow10(exactAssetPrecision(base.Asset))),
@@ -177,13 +177,15 @@ func (e *evalCtx) sourceConsensus(args ...ref.Val) ref.Val {
 	}
 
 	var minimum, maximum *big.Int
+	missing := false
 	for i, balance := range balances {
 		value, present, resolveErr := e.resolveExactBalanceWithPresence(balance)
 		if resolveErr != nil {
 			return types.NewErr("sourceConsensus: resolve source %d: %v", i, resolveErr)
 		}
 		if !present {
-			return types.False
+			missing = true
+			continue
 		}
 		if minimum == nil || value.Cmp(minimum) < 0 {
 			minimum = new(big.Int).Set(value)
@@ -191,6 +193,9 @@ func (e *evalCtx) sourceConsensus(args ...ref.Val) ref.Val {
 		if maximum == nil || value.Cmp(maximum) > 0 {
 			maximum = new(big.Int).Set(value)
 		}
+	}
+	if missing {
+		return types.False
 	}
 
 	spread := new(big.Int).Sub(maximum, minimum)

--- a/internal/ledgerschema/addresses.go
+++ b/internal/ledgerschema/addresses.go
@@ -22,9 +22,10 @@ const DefaultControlLedger = "reconciliation"
 // Assets minted in the control-ledger (precision 0 — they are markers/counters,
 // not money).
 const (
-	AssetAlert   = "ALERT"   // lifecycle marker: exactly one unit per live alert
-	AssetOcc     = "OCC"     // per-alert occurrence counter (balance on the item account)
-	AssetCapture = "CAPTURE" // one unit minted per recorded evaluation (capture counter)
+	AssetAlert    = "ALERT"    // lifecycle marker: exactly one unit per live alert
+	AssetOcc      = "OCC"      // per-alert occurrence counter (balance on the item account)
+	AssetCapture  = "CAPTURE"  // one unit minted per recorded evaluation (capture counter)
+	AssetActivity = "ACTIVITY" // one unit per rule lifecycle, evaluation, or alert activity
 )
 
 // Lifecycle states — the {state} segment of a marker account. The marker sits in
@@ -107,6 +108,12 @@ func CaptureAccount(ruleID, period string) string {
 func CapturePool(ruleID string) string {
 	return "capture:pool:rule:" + ruleID
 }
+
+// ActivityAccount is the single append-only transaction stream for a rule.
+func ActivityAccount(ruleID string) string { return "activity:rule:" + ruleID }
+
+// ActivityPool mints the precision-zero activity counter for a rule.
+func ActivityPool(ruleID string) string { return "activity:pool:rule:" + ruleID }
 
 // CaptureRulePrefix matches all capture buckets of a rule across every period
 // (`capture:rule:{ruleID}:per:*`). Used to list a rule's full capture history as

--- a/internal/ledgerschema/schema.go
+++ b/internal/ledgerschema/schema.go
@@ -4,12 +4,25 @@ import "github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
 
 // Account-type names (used as the AccountType.Name / the "family" identifier).
 const (
-	AccountTypeRule        = "rule"
-	AccountTypeAlertItem   = "alert-item"
-	AccountTypeAlertState  = "alert-state"
-	AccountTypeAlertPool   = "alert-pool"
-	AccountTypeCapture     = "capture"      // per-(rule,period) capture bucket (ADR-003)
-	AccountTypeCapturePool = "capture-pool" // per-rule capture mint source
+	AccountTypeRule         = "rule"
+	AccountTypeAlertItem    = "alert-item"
+	AccountTypeAlertState   = "alert-state"
+	AccountTypeAlertPool    = "alert-pool"
+	AccountTypeCapture      = "capture"      // per-(rule,period) capture bucket (ADR-003)
+	AccountTypeCapturePool  = "capture-pool" // per-rule capture mint source
+	AccountTypeActivity     = "activity"
+	AccountTypeActivityPool = "activity-pool"
+)
+
+const (
+	ActivityMetaSchemaVersion   = "activity_schema_version"
+	ActivityMetaKind            = "activity_kind"
+	ActivityMetaRule            = "activity_rule_id"
+	ActivityMetaAt              = "activity_occurred_at"
+	ActivityMetaContractVersion = "activity_contract_version"
+	ActivityMetaRevision        = "activity_rule_revision"
+	ActivityMetaCorrelation     = "activity_correlation_id"
+	ActivityMetaPayload         = "activity_payload"
 )
 
 // Capture transaction metadata keys — the self-describing capture envelope stamped
@@ -17,16 +30,22 @@ const (
 // (COMMITTED_TRANSACTION payload), undeclared like the alert labels: stored as-is,
 // not indexed. The immutable, receipt-signed transaction is the audit record.
 const (
-	CaptureType     = "reconciliation.capture" // value of CaptureMetaType
-	CaptureMetaType = "type"
-	CaptureMetaRule = "rule_id"
-	CaptureMetaTmpl = "template_kind"
-	CaptureMetaPer  = "period"
-	CaptureMetaEval = "evaluation_id"
-	CaptureMetaAt   = "captured_at"
-	CaptureMetaVdt  = "verdict"
-	CaptureMetaTrig = "trigger"
-	CaptureMetaEvi  = "evidence"
+	CaptureType                = "reconciliation.capture" // value of CaptureMetaType
+	CaptureMetaType            = "type"
+	CaptureMetaRule            = "rule_id"
+	CaptureMetaTmpl            = "template_kind"
+	CaptureMetaPer             = "period"
+	CaptureMetaEval            = "evaluation_id"
+	CaptureMetaAt              = "captured_at"
+	CaptureMetaVdt             = "verdict"
+	CaptureMetaTrig            = "trigger"
+	CaptureMetaEvi             = "evidence"
+	CaptureMetaContractVersion = "contract_version"
+	CaptureMetaRevision        = "rule_revision"
+	CaptureMetaStartedAt       = "started_at"
+	CaptureMetaPIT             = "pit"
+	CaptureMetaResult          = "result"
+	CaptureMetaError           = "error"
 )
 
 // Metadata keys on the canonical alert (`alert:item:*`) account.
@@ -53,16 +72,18 @@ const (
 
 // Metadata keys on the rule (`rule:*`) account.
 const (
-	MetaName          = "name"
-	MetaTemplateKind  = "template_kind"
-	MetaEnabled       = "enabled"
-	MetaSchedule      = "schedule" // JSON
-	MetaCadence       = "cadence"
-	MetaSpec          = "spec" // JSON
-	MetaCompiledCEL   = "compiled_cel"
-	MetaNotifications = "notifications" // JSON array
-	MetaCreatedAt     = "created_at"
-	MetaUpdatedAt     = "updated_at"
+	MetaName            = "name"
+	MetaTemplateKind    = "template_kind"
+	MetaEnabled         = "enabled"
+	MetaSchedule        = "schedule" // JSON
+	MetaCadence         = "cadence"
+	MetaSpec            = "spec" // JSON
+	MetaCompiledCEL     = "compiled_cel"
+	MetaNotifications   = "notifications" // JSON array
+	MetaContractVersion = "contract_version"
+	MetaCreatedAt       = "created_at"
+	MetaUpdatedAt       = "updated_at"
+	MetaRevision        = "revision"
 )
 
 // LabelPrefix namespaces a rule/alert label as a flat, indexable metadata key
@@ -71,8 +92,9 @@ const (
 const LabelPrefix = "label."
 
 // AccountTypes returns the chart of accounts declared on the control-ledger.
-// Applied at bootstrap; combined with STRICT enforcement, any write to an
-// address outside these patterns is rejected by the FSM (see RFC §4.1.3).
+// Applied at bootstrap. Once STRICT enforcement is enabled, any write to an
+// address outside these patterns is rejected by the FSM; the current server
+// provisions in AUDIT mode during rollout (see RFC §4.1.3).
 func AccountTypes() map[string]*commonpb.AccountType {
 	uuid := func() *commonpb.SegmentType {
 		return &commonpb.SegmentType{Constraint: &commonpb.SegmentType_Uuid{Uuid: &commonpb.UUIDConstraint{}}}
@@ -135,6 +157,16 @@ func AccountTypes() map[string]*commonpb.AccountType {
 			Persistence:  commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
 			SegmentTypes: map[string]*commonpb.SegmentType{"ruleId": uuid()},
 		},
+		AccountTypeActivity: {
+			Name: AccountTypeActivity, Pattern: "activity:rule:{ruleId}",
+			Persistence:  commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
+			SegmentTypes: map[string]*commonpb.SegmentType{"ruleId": uuid()},
+		},
+		AccountTypeActivityPool: {
+			Name: AccountTypeActivityPool, Pattern: "activity:pool:rule:{ruleId}",
+			Persistence:  commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
+			SegmentTypes: map[string]*commonpb.SegmentType{"ruleId": uuid()},
+		},
 	}
 }
 
@@ -161,8 +193,8 @@ func MetadataSchema() []*commonpb.SetMetadataFieldTypeCommand {
 		{MetaEvidence, str}, {MetaResolution, str}, {MetaAck, str}, {MetaSnooze, str},
 		// rule
 		{MetaName, str}, {MetaTemplateKind, str}, {MetaEnabled, b}, {MetaSchedule, str},
-		{MetaCadence, str}, {MetaSpec, str}, {MetaCompiledCEL, str}, {MetaNotifications, str},
-		{MetaCreatedAt, dt}, {MetaUpdatedAt, dt},
+		{MetaCadence, str}, {MetaSpec, str}, {MetaCompiledCEL, str}, {MetaNotifications, str}, {MetaContractVersion, str},
+		{MetaCreatedAt, dt}, {MetaUpdatedAt, dt}, {MetaRevision, str},
 	}
 
 	cmds := make([]*commonpb.SetMetadataFieldTypeCommand, 0, len(fields))

--- a/internal/ledgerschema/scripts.go
+++ b/internal/ledgerschema/scripts.go
@@ -6,20 +6,21 @@ import "fmt"
 // in the ledger's numscript library (SaveNumscript, validated at save time) and
 // referenced by name+version at transaction time (ScriptReference), instead of
 // inlining the source in every request. Accounts are passed as vars — addresses
-// are dynamic (rule/period/fp) — and STRICT enforcement is the backstop that
-// rejects any address outside the declared chart. See RFC §4.1.2 and
+// are dynamic (rule/period/fp). STRICT enforcement will reject any address
+// outside the declared chart once enabled; the current rollout uses AUDIT. See RFC §4.1.2 and
 // docs/technical/architecture/subsystems/scripting/numscript-library.md.
 
 // Numscript names and the pinned version. Library semver is immutable: bump the
 // version when a program's content changes, and update the reference in lockstep.
 const (
-	NumscriptVersion = "1.0.0"
+	NumscriptVersion = "2.0.0"
 
 	NumscriptAlertOpen   = "alert_open"   // mint marker → st:open + mint OCC → item (new alert)
 	NumscriptAlertBump   = "alert_bump"   // mint OCC → item (repeat, marker stays put)
 	NumscriptAlertReopen = "alert_reopen" // guarded move st:{from}→st:open + mint OCC (reopen/resurface)
 	NumscriptAlertMove   = "alert_move"   // guarded move st:{from}→st:{to}, no OCC (ack/resolve/accept/auto-resolve)
 	NumscriptCapture     = "capture"      // mint 1 CAPTURE → capture bucket (records one evaluation)
+	NumscriptActivity    = "activity"     // append one event to a rule's activity stream
 )
 
 // Numscript var names — the account addresses passed per call.
@@ -30,8 +31,10 @@ const (
 	VarStFrom = "st_from" // the marker's current state account (guarded move source)
 	VarStTo   = "st_to"   // the marker's target state account (guarded move destination)
 
-	VarCapturePool = "capture_pool" // the per-rule capture overdraft source
-	VarCapture     = "capture"      // the (rule, period) capture bucket account
+	VarCapturePool  = "capture_pool" // the per-rule capture overdraft source
+	VarCapture      = "capture"      // the (rule, period) capture bucket account
+	VarActivityPool = "activity_pool"
+	VarActivity     = "activity"
 )
 
 // NumscriptDef is one library program to register at provisioning.
@@ -51,6 +54,7 @@ func Numscripts() []NumscriptDef {
 		{NumscriptAlertReopen, alertReopenContent(), NumscriptVersion},
 		{NumscriptAlertMove, alertMoveContent(), NumscriptVersion},
 		{NumscriptCapture, captureContent(), NumscriptVersion},
+		{NumscriptActivity, activityContent(), NumscriptVersion},
 	}
 }
 
@@ -62,11 +66,28 @@ func captureContent() string {
 	return fmt.Sprintf(`vars {
 	account $%[1]s
 	account $%[2]s
+	account $%[3]s
+	account $%[4]s
+}
+send [%[5]s 1] (
+	source = $%[1]s allowing unbounded overdraft
+	destination = $%[2]s
+)
+send [%[6]s 1] (
+	source = $%[3]s allowing unbounded overdraft
+	destination = $%[4]s
+)`, VarCapturePool, VarCapture, VarActivityPool, VarActivity, AssetCapture, AssetActivity)
+}
+
+func activityContent() string {
+	return fmt.Sprintf(`vars {
+	account $%[1]s
+	account $%[2]s
 }
 send [%[3]s 1] (
 	source = $%[1]s allowing unbounded overdraft
 	destination = $%[2]s
-)`, VarCapturePool, VarCapture, AssetCapture)
+)`, VarActivityPool, VarActivity, AssetActivity)
 }
 
 // alertOpenContent mints the single ALERT marker into st:open (overdraft, the
@@ -77,15 +98,21 @@ func alertOpenContent() string {
 	account $%[1]s
 	account $%[2]s
 	account $%[3]s
+	account $%[4]s
+	account $%[5]s
 }
-send [%[4]s 1] (
+send [%[6]s 1] (
 	source = $%[1]s allowing unbounded overdraft
 	destination = $%[2]s
 )
-send [%[5]s 1] (
+send [%[7]s 1] (
 	source = $%[1]s allowing unbounded overdraft
 	destination = $%[3]s
-)`, VarPool, VarStOpen, VarItem, AssetAlert, AssetOcc)
+)
+send [%[8]s 1] (
+	source = $%[4]s allowing unbounded overdraft
+	destination = $%[5]s
+)`, VarPool, VarStOpen, VarItem, VarActivityPool, VarActivity, AssetAlert, AssetOcc, AssetActivity)
 }
 
 // alertBumpContent increments the item's OCC counter by one (a repeat failure —
@@ -94,11 +121,17 @@ func alertBumpContent() string {
 	return fmt.Sprintf(`vars {
 	account $%[1]s
 	account $%[2]s
+	account $%[3]s
+	account $%[4]s
 }
-send [%[3]s 1] (
+send [%[5]s 1] (
 	source = $%[1]s allowing unbounded overdraft
 	destination = $%[2]s
-)`, VarPool, VarItem, AssetOcc)
+)
+send [%[6]s 1] (
+	source = $%[3]s allowing unbounded overdraft
+	destination = $%[4]s
+)`, VarPool, VarItem, VarActivityPool, VarActivity, AssetOcc, AssetActivity)
 }
 
 // alertMoveContent moves the ALERT marker between two state accounts, no OCC
@@ -108,11 +141,17 @@ func alertMoveContent() string {
 	return fmt.Sprintf(`vars {
 	account $%[1]s
 	account $%[2]s
+	account $%[3]s
+	account $%[4]s
 }
-send [%[3]s 1] (
+send [%[5]s 1] (
 	source = $%[1]s
 	destination = $%[2]s
-)`, VarStFrom, VarStTo, AssetAlert)
+)
+send [%[6]s 1] (
+	source = $%[3]s allowing unbounded overdraft
+	destination = $%[4]s
+)`, VarStFrom, VarStTo, VarActivityPool, VarActivity, AssetAlert, AssetActivity)
 }
 
 // alertReopenContent moves the ALERT marker st:{from}→st:open and bumps OCC. The
@@ -125,13 +164,19 @@ func alertReopenContent() string {
 	account $%[2]s
 	account $%[3]s
 	account $%[4]s
+	account $%[5]s
+	account $%[6]s
 }
-send [%[5]s 1] (
+send [%[7]s 1] (
 	source = $%[2]s
 	destination = $%[3]s
 )
-send [%[6]s 1] (
+send [%[8]s 1] (
 	source = $%[1]s allowing unbounded overdraft
 	destination = $%[4]s
-)`, VarPool, VarStFrom, VarStOpen, VarItem, AssetAlert, AssetOcc)
+)
+send [%[9]s 1] (
+	source = $%[5]s allowing unbounded overdraft
+	destination = $%[6]s
+)`, VarPool, VarStFrom, VarStOpen, VarItem, VarActivityPool, VarActivity, AssetAlert, AssetOcc, AssetActivity)
 }

--- a/internal/ledgerschema/scripts_test.go
+++ b/internal/ledgerschema/scripts_test.go
@@ -17,12 +17,13 @@ func TestNumscripts(t *testing.T) {
 		byName[ns.Name] = ns
 	}
 
-	require.Len(t, byName, 5)
+	require.Len(t, byName, 6)
 	require.Contains(t, byName, NumscriptAlertOpen)
 	require.Contains(t, byName, NumscriptAlertBump)
 	require.Contains(t, byName, NumscriptAlertReopen)
 	require.Contains(t, byName, NumscriptAlertMove)
 	require.Contains(t, byName, NumscriptCapture)
+	require.Contains(t, byName, NumscriptActivity)
 }
 
 func TestNumscriptCapture(t *testing.T) {
@@ -45,7 +46,7 @@ func TestNumscriptAlertMove(t *testing.T) {
 	// Pure guarded move st_from → st_to: bare source (CAS), no OCC, no pool.
 	require.Contains(t, c, "source = $"+VarStFrom+"\n")
 	require.Contains(t, c, "destination = $"+VarStTo)
-	require.NotContains(t, c, "allowing unbounded overdraft")
+	require.NotContains(t, c, "$"+VarStFrom+" allowing unbounded overdraft")
 	require.NotContains(t, c, "["+AssetOcc+" 1]")
 	requireDeclaresVars(t, c, VarStFrom, VarStTo)
 }

--- a/internal/ledgerstore/activity.go
+++ b/internal/ledgerstore/activity.go
@@ -106,8 +106,17 @@ func (s *LedgerStore) ListRuleActivities(ctx context.Context, ruleID uuid.UUID, 
 	}); err != nil {
 		return nil, fmt.Errorf("list activities for rule %s: %w", ruleID, err)
 	}
-	if len(items) == 0 && seenOtherContract {
-		return nil, fmt.Errorf("list activities for rule %s: %w", ruleID, store.ErrNotFound)
+	if len(items) == 0 {
+		if seenOtherContract {
+			return nil, fmt.Errorf("list activities for rule %s: %w", ruleID, store.ErrNotFound)
+		}
+		rule, err := s.GetRule(ctx, ruleID)
+		if err != nil {
+			return nil, err
+		}
+		if version := q.Options.Options.ContractVersion; version != nil && rule.ContractVersion.Effective() != *version {
+			return nil, fmt.Errorf("list activities for rule %s: %w", ruleID, store.ErrNotFound)
+		}
 	}
 	slices.SortFunc(items, func(a, b models.RuleActivity) int {
 		if c := b.OccurredAt.Compare(a.OccurredAt); c != 0 {

--- a/internal/ledgerstore/activity.go
+++ b/internal/ledgerstore/activity.go
@@ -1,0 +1,128 @@
+package ledgerstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/formancehq/go-libs/bun/bunpaginate"
+	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
+	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
+	"github.com/formancehq/reconciliation/internal/models"
+	"github.com/formancehq/reconciliation/internal/store"
+	"github.com/google/uuid"
+)
+
+func ruleRevision(r *models.Rule) (string, error) {
+	spec := r.TemplateSpec
+	if len(spec) == 0 {
+		spec = json.RawMessage(`null`)
+	}
+	config := struct {
+		Name          string              `json:"name"`
+		TemplateKind  models.TemplateKind `json:"templateKind"`
+		TemplateSpec  json.RawMessage     `json:"templateSpec"`
+		CompiledCEL   string              `json:"compiledCEL"`
+		Enabled       bool                `json:"enabled"`
+		Severity      models.Severity     `json:"severity"`
+		Cadence       models.Cadence      `json:"cadence"`
+		Schedule      *models.Schedule    `json:"schedule,omitempty"`
+		Notifications []string            `json:"notifications,omitempty"`
+		Labels        map[string]string   `json:"labels,omitempty"`
+	}{r.Name, r.TemplateKind, spec, r.CompiledCEL, r.Enabled, r.Severity, r.Cadence, r.Schedule, r.Notifications, r.Labels}
+	b, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func activityVars(ruleID string) map[string]string {
+	return map[string]string{schema.VarActivityPool: schema.ActivityPool(ruleID), schema.VarActivity: schema.ActivityAccount(ruleID)}
+}
+
+func addActivityVars(vars map[string]string, ruleID string) map[string]string {
+	for k, v := range activityVars(ruleID) {
+		vars[k] = v
+	}
+	return vars
+}
+
+func activityMetadata(kind string, ruleID uuid.UUID, version models.ContractVersion, revision, correlation string, at time.Time, payload any) (map[string]*commonpb.MetadataValue, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]*commonpb.MetadataValue{
+		schema.ActivityMetaSchemaVersion: strVal("1"), schema.ActivityMetaKind: strVal(kind), schema.ActivityMetaRule: strVal(ruleID.String()),
+		schema.ActivityMetaAt: strVal(at.UTC().Format(time.RFC3339Nano)), schema.ActivityMetaContractVersion: strVal(strconv.Itoa(int(version.Effective()))),
+		schema.ActivityMetaRevision: strVal(revision), schema.ActivityMetaCorrelation: strVal(correlation), schema.ActivityMetaPayload: strVal(string(b)),
+	}, nil
+}
+
+func activityFromTransaction(tx *commonpb.Transaction) (models.RuleActivity, bool) {
+	md := tx.GetMetadata()
+	kind := getStr(md, schema.ActivityMetaKind)
+	if kind == "" {
+		return models.RuleActivity{}, false
+	}
+	id, err := uuid.Parse(getStr(md, schema.ActivityMetaRule))
+	if err != nil {
+		return models.RuleActivity{}, false
+	}
+	version := models.ContractVersionV1
+	if v, err := strconv.Atoi(getStr(md, schema.ActivityMetaContractVersion)); err == nil && v > 0 {
+		version = models.ContractVersion(v)
+	}
+	at, _ := time.Parse(time.RFC3339Nano, getStr(md, schema.ActivityMetaAt))
+	category, _, _ := strings.Cut(kind, ".")
+	seq := strconv.FormatUint(tx.GetId(), 10)
+	recordedAt := at.UTC()
+	if ts := tx.GetInsertedAt(); ts != nil && ts.GetData() != 0 {
+		recordedAt = time.UnixMicro(int64(ts.GetData())).UTC()
+	}
+	return models.RuleActivity{ID: seq + ":0", Sequence: seq, Kind: kind, Category: category, RuleID: id, ContractVersion: version, RuleRevision: getStr(md, schema.ActivityMetaRevision), CorrelationID: getStr(md, schema.ActivityMetaCorrelation), OccurredAt: at.UTC(), RecordedAt: recordedAt, Payload: json.RawMessage(getStr(md, schema.ActivityMetaPayload))}, true
+}
+
+func (s *LedgerStore) ListRuleActivities(ctx context.Context, ruleID uuid.UUID, q store.GetRuleActivitiesQuery) (*bunpaginate.Cursor[models.RuleActivity], error) {
+	items := make([]models.RuleActivity, 0, 64)
+	seenOtherContract := false
+	if err := s.client.ListTransactionsFunc(ctx, s.controlLedger, schema.FilterAddressPrefix(schema.ActivityAccount(ruleID.String())), func(tx *commonpb.Transaction) error {
+		if item, ok := activityFromTransaction(tx); ok {
+			if q.Options.Options.ContractVersion != nil && item.ContractVersion.Effective() != *q.Options.Options.ContractVersion {
+				seenOtherContract = true
+				return nil
+			}
+			items = append(items, item)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("list activities for rule %s: %w", ruleID, err)
+	}
+	if len(items) == 0 && seenOtherContract {
+		return nil, fmt.Errorf("list activities for rule %s: %w", ruleID, store.ErrNotFound)
+	}
+	slices.SortFunc(items, func(a, b models.RuleActivity) int {
+		if c := b.OccurredAt.Compare(a.OccurredAt); c != 0 {
+			return c
+		}
+		as, _ := strconv.ParseUint(a.Sequence, 10, 64)
+		bs, _ := strconv.ParseUint(b.Sequence, 10, 64)
+		if bs < as {
+			return -1
+		}
+		if bs > as {
+			return 1
+		}
+		return 0
+	})
+	data, more := paginateSlice(items, q.Offset, q.PageSize)
+	return offsetCursor(bunpaginate.OffsetPaginatedQuery[store.PaginatedQueryOptions[store.RuleActivitiesFilters]](q), data, more), nil
+}

--- a/internal/ledgerstore/activity_test.go
+++ b/internal/ledgerstore/activity_test.go
@@ -55,3 +55,47 @@ func TestListRuleActivitiesHidesOtherContract(t *testing.T) {
 	_, err := New(client, controlLedger).ListRuleActivities(context.Background(), ruleID, q)
 	require.ErrorIs(t, err, store.ErrNotFound)
 }
+
+func TestListRuleActivitiesEmptyStreamRequiresMatchingRule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		storedRule  *models.Rule
+		query       models.ContractVersion
+		wantMissing bool
+	}{
+		{name: "missing rule", query: models.ContractVersionV2, wantMissing: true},
+		{name: "matching rule", storedRule: newRule(uuid.New()), query: models.ContractVersionV1},
+		{name: "other contract", storedRule: newRule(uuid.New()), query: models.ContractVersionV2, wantMissing: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			client := NewMockledgerClient(ctrl)
+			ruleID := uuid.New()
+			if tt.storedRule != nil {
+				tt.storedRule.ID = ruleID
+			}
+
+			client.EXPECT().ListTransactionsFunc(gomock.Any(), controlLedger, gomock.Any(), gomock.Any()).Return(nil)
+			get := client.EXPECT().GetAccount(gomock.Any(), controlLedger, schema.RuleAccount(ruleID.String()))
+			if tt.storedRule == nil {
+				get.Return(nil, notFound())
+			} else {
+				get.Return(account(t, tt.storedRule), nil)
+			}
+
+			q := store.NewGetRuleActivitiesQuery(store.NewPaginatedQueryOptions(store.RuleActivitiesFilters{ContractVersion: &tt.query}))
+			cur, err := New(client, controlLedger).ListRuleActivities(context.Background(), ruleID, q)
+			if tt.wantMissing {
+				require.ErrorIs(t, err, store.ErrNotFound)
+				return
+			}
+			require.NoError(t, err)
+			require.Empty(t, cur.Data)
+		})
+	}
+}

--- a/internal/ledgerstore/activity_test.go
+++ b/internal/ledgerstore/activity_test.go
@@ -1,0 +1,57 @@
+package ledgerstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
+	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
+	"github.com/formancehq/reconciliation/internal/models"
+	"github.com/formancehq/reconciliation/internal/store"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestListRuleActivitiesCombinesAndOrdersKinds(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := NewMockledgerClient(ctrl)
+	ruleID := uuid.New()
+	t0 := time.Now().UTC()
+	makeTx := func(id uint64, kind string, at time.Time) *commonpb.Transaction {
+		md, err := activityMetadata(kind, ruleID, models.ContractVersionV2, "sha256:r", "eval", at, map[string]any{"ok": true})
+		require.NoError(t, err)
+		return &commonpb.Transaction{Id: id, Metadata: md}
+	}
+	client.EXPECT().ListTransactionsFunc(gomock.Any(), controlLedger, gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, filter *commonpb.QueryFilter, fn func(*commonpb.Transaction) error) error {
+		require.Equal(t, schema.ActivityAccount(ruleID.String()), filter.GetAddress().GetHardcodedPrefix())
+		require.NoError(t, fn(makeTx(10, "rule.updated", t0.Add(-time.Minute))))
+		require.NoError(t, fn(makeTx(11, "evaluation.completed", t0)))
+		require.NoError(t, fn(makeTx(12, "alert.opened", t0)))
+		return nil
+	})
+	version := models.ContractVersionV2
+	q := store.NewGetRuleActivitiesQuery(store.NewPaginatedQueryOptions(store.RuleActivitiesFilters{ContractVersion: &version}))
+	cur, err := New(client, controlLedger).ListRuleActivities(context.Background(), ruleID, q)
+	require.NoError(t, err)
+	require.Equal(t, []string{"alert.opened", "evaluation.completed", "rule.updated"}, []string{cur.Data[0].Kind, cur.Data[1].Kind, cur.Data[2].Kind})
+	require.Equal(t, "12:0", cur.Data[0].ID)
+}
+
+func TestListRuleActivitiesHidesOtherContract(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	client := NewMockledgerClient(ctrl)
+	ruleID := uuid.New()
+	client.EXPECT().ListTransactionsFunc(gomock.Any(), controlLedger, gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *commonpb.QueryFilter, fn func(*commonpb.Transaction) error) error {
+		md, err := activityMetadata("rule.created", ruleID, models.ContractVersionV2, "r", "", time.Now(), map[string]any{})
+		require.NoError(t, err)
+		return fn(&commonpb.Transaction{Id: 1, Metadata: md})
+	})
+	version := models.ContractVersionV1
+	q := store.NewGetRuleActivitiesQuery(store.NewPaginatedQueryOptions(store.RuleActivitiesFilters{ContractVersion: &version}))
+	_, err := New(client, controlLedger).ListRuleActivities(context.Background(), ruleID, q)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/internal/ledgerstore/alert.go
+++ b/internal/ledgerstore/alert.go
@@ -92,6 +92,7 @@ func (s *LedgerStore) openNewAlert(ctx context.Context, in store.OpenAlertInput,
 	alert := &models.Alert{
 		ID:               uuid.New(),
 		RuleID:           in.RuleID,
+		ContractVersion:  in.ContractVersion.Effective(),
 		Fingerprint:      in.Fingerprint,
 		PeriodID:         in.PeriodID,
 		Status:           models.AlertOpen,
@@ -103,6 +104,7 @@ func (s *LedgerStore) openNewAlert(ctx context.Context, in store.OpenAlertInput,
 		Evidence:         in.Evidence,
 		Labels:           in.Labels,
 		CreatedAt:        in.OccurredAt,
+		UpdatedAt:        in.OccurredAt,
 	}
 
 	md, err := alertToMetadata(alert)
@@ -114,16 +116,23 @@ func (s *LedgerStore) openNewAlert(ctx context.Context, in store.OpenAlertInput,
 		map[string]any{"occurrenceCount": alert.OccurrenceCount}); err != nil {
 		return nil, fmt.Errorf("open alert %s: %w", in.Fingerprint, err)
 	}
+	txmd, err := alertActivityMetadata(alert, md)
+	if err != nil {
+		return nil, fmt.Errorf("open alert %s activity: %w", in.Fingerprint, err)
+	}
 
 	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{
 		Ledger:        s.controlLedger,
 		ScriptName:    schema.NumscriptAlertOpen,
 		ScriptVersion: schema.NumscriptVersion,
 		Vars: map[string]string{
-			schema.VarPool:   schema.PoolAccount(rule),
-			schema.VarStOpen: schema.AlertStateAccount(schema.StateOpen, rule, in.PeriodID, fpHash),
-			schema.VarItem:   itemAddr,
+			schema.VarPool:         schema.PoolAccount(rule),
+			schema.VarStOpen:       schema.AlertStateAccount(schema.StateOpen, rule, in.PeriodID, fpHash),
+			schema.VarItem:         itemAddr,
+			schema.VarActivityPool: schema.ActivityPool(rule),
+			schema.VarActivity:     schema.ActivityAccount(rule),
 		},
+		TxMetadata:      txmd,
 		AccountMetadata: map[string]*commonpb.MetadataMap{itemAddr: {Values: md}},
 		IdempotencyKey:  alertBatchKey(in),
 	}); err != nil {
@@ -146,6 +155,7 @@ func (s *LedgerStore) updateAlert(ctx context.Context, in store.OpenAlertInput, 
 	prior.OccurrenceCount++
 	prior.Status = models.AlertOpen
 	prior.LastSeenAt = in.OccurredAt
+	prior.UpdatedAt = in.OccurredAt
 	prior.LastEvaluationID = in.EvaluationID
 	prior.Evidence = in.Evidence
 
@@ -184,6 +194,10 @@ func (s *LedgerStore) updateAlert(ctx context.Context, in store.OpenAlertInput, 
 		DeleteMetadata:  deletes,
 		IdempotencyKey:  alertBatchKey(in),
 	}
+	tx.TxMetadata, err = alertActivityMetadata(prior, md)
+	if err != nil {
+		return nil, fmt.Errorf("update alert %s activity: %w", in.Fingerprint, err)
+	}
 
 	stOpen := schema.AlertStateAccount(schema.StateOpen, rule, in.PeriodID, fpHash)
 
@@ -215,6 +229,7 @@ func (s *LedgerStore) updateAlert(ctx context.Context, in store.OpenAlertInput, 
 			schema.VarItem:   itemAddr,
 		}
 	}
+	addActivityVars(tx.Vars, rule)
 
 	if err := s.client.CreateTransaction(ctx, tx); err != nil {
 		return nil, fmt.Errorf("update alert %s: %w", in.Fingerprint, err)

--- a/internal/ledgerstore/alert.go
+++ b/internal/ledgerstore/alert.go
@@ -274,3 +274,11 @@ func alertActionKey(parts ...string) string {
 
 	return hex.EncodeToString(sum[:])
 }
+
+// uniqueActionKey identifies a newly accepted API operation while remaining
+// stable for any transport retry of the resulting CreateTransaction call.
+// Use it when the API has no caller-supplied operation ID and repeating the
+// same business value still represents a new audit event.
+func uniqueActionKey(parts ...string) string {
+	return alertActionKey(append(parts, uuid.NewString())...)
+}

--- a/internal/ledgerstore/alert_metadata.go
+++ b/internal/ledgerstore/alert_metadata.go
@@ -56,6 +56,8 @@ func alertToMetadata(a *models.Alert) (map[string]*commonpb.MetadataValue, error
 		schema.MetaLastSeenAt:       dtVal(a.LastSeenAt),
 		schema.MetaLastEvaluationID: strVal(a.LastEvaluationID.String()),
 		schema.MetaCreatedAt:        dtVal(a.CreatedAt),
+		schema.MetaUpdatedAt:        dtVal(a.UpdatedAt),
+		schema.MetaContractVersion:  strVal(strconv.Itoa(int(a.ContractVersion.Effective()))),
 	}
 
 	if len(a.Evidence) > 0 {
@@ -101,6 +103,7 @@ func alertFromAccount(acct *commonpb.Account) (*models.Alert, error) {
 
 	a := &models.Alert{
 		ID:              id,
+		ContractVersion: getContractVersion(md),
 		RuleID:          ruleID,
 		Fingerprint:     getStr(md, schema.MetaFingerprint),
 		PeriodID:        getStr(md, schema.MetaPeriod),
@@ -109,6 +112,7 @@ func alertFromAccount(acct *commonpb.Account) (*models.Alert, error) {
 		FirstSeenAt:     getTime(md, schema.MetaFirstSeenAt),
 		LastSeenAt:      getTime(md, schema.MetaLastSeenAt),
 		CreatedAt:       getTime(md, schema.MetaCreatedAt),
+		UpdatedAt:       getTime(md, schema.MetaUpdatedAt),
 		OccurrenceCount: occurrenceCount(acct),
 	}
 
@@ -149,12 +153,7 @@ func alertFromAccount(acct *commonpb.Account) (*models.Alert, error) {
 
 // occurrenceCount reads the alert's OCC balance (a decimal big.Int string).
 func occurrenceCount(acct *commonpb.Account) int64 {
-	v := acct.GetVolumes()[schema.AssetOcc]
-	if v == nil {
-		return 0
-	}
-
-	n, _ := strconv.ParseInt(v.GetBalance(), 10, 64)
+	n, _ := strconv.ParseInt(commonpb.BalanceByAsset(acct, schema.AssetOcc).String(), 10, 64)
 
 	return n
 }

--- a/internal/ledgerstore/alert_metadata_test.go
+++ b/internal/ledgerstore/alert_metadata_test.go
@@ -46,7 +46,10 @@ func TestAlertMetadataRoundTrip(t *testing.T) {
 	acct := &commonpb.Account{
 		Address:  schema.AlertItemAccount(ruleID.String(), orig.PeriodID, schema.FingerprintHash(orig.Fingerprint)),
 		Metadata: md,
-		Volumes:  map[string]*commonpb.VolumesWithBalance{schema.AssetOcc: {Balance: "3"}},
+		Volumes: []*commonpb.AccountVolume{
+			{Asset: schema.AssetOcc, Volumes: &commonpb.VolumesWithBalance{Balance: "2"}},
+			{Asset: schema.AssetOcc, Color: "RETRY", Volumes: &commonpb.VolumesWithBalance{Balance: "1"}},
+		},
 	}
 
 	got, err := alertFromAccount(acct)
@@ -89,6 +92,26 @@ func TestAlertMetadataNoOccVolume(t *testing.T) {
 	require.Nil(t, got.Resolution)
 	require.Nil(t, got.Snooze)
 	require.Empty(t, got.Labels)
+}
+
+func TestAlertMetadataContractVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	base := &models.Alert{ID: uuid.New(), RuleID: uuid.New()}
+	md, err := alertToMetadata(base)
+	require.NoError(t, err)
+	delete(md, schema.MetaContractVersion)
+	got, err := alertFromAccount(&commonpb.Account{Metadata: md})
+	require.NoError(t, err)
+	require.Equal(t, models.ContractVersionV1, got.ContractVersion)
+
+	base.ContractVersion = models.ContractVersionV2
+	md, err = alertToMetadata(base)
+	require.NoError(t, err)
+	require.Equal(t, "2", md[schema.MetaContractVersion].GetStringValue())
+	got, err = alertFromAccount(&commonpb.Account{Metadata: md})
+	require.NoError(t, err)
+	require.Equal(t, models.ContractVersionV2, got.ContractVersion)
 }
 
 func TestStatusStateMapping(t *testing.T) {

--- a/internal/ledgerstore/alert_read.go
+++ b/internal/ledgerstore/alert_read.go
@@ -87,7 +87,9 @@ func (s *LedgerStore) ListAlerts(ctx context.Context, q store.GetAlertsQuery) (*
 			return nil, fmt.Errorf("list alerts: decode %s: %w", acct.GetAddress(), derr)
 		}
 
-		alerts = append(alerts, *a)
+		if version := q.Options.Options.ContractVersion; version == nil || a.ContractVersion.Effective() == *version {
+			alerts = append(alerts, *a)
+		}
 	}
 
 	slices.SortFunc(alerts, func(a, b models.Alert) int { return b.LastSeenAt.Compare(a.LastSeenAt) })

--- a/internal/ledgerstore/alert_snooze.go
+++ b/internal/ledgerstore/alert_snooze.go
@@ -55,7 +55,7 @@ func (s *LedgerStore) SnoozeAlert(ctx context.Context, id uuid.UUID, until time.
 	if err != nil {
 		return nil, fmt.Errorf("snooze alert %s activity: %w", id, err)
 	}
-	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(alert.RuleID.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{itemAddr: {Values: md}}, IdempotencyKey: alertActionKey("snooze", id.String(), until.UTC().Format(time.RFC3339Nano))}); err != nil {
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(alert.RuleID.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{itemAddr: {Values: md}}, IdempotencyKey: uniqueActionKey("snooze", id.String(), until.UTC().Format(time.RFC3339Nano))}); err != nil {
 		return nil, fmt.Errorf("snooze alert %s: %w", id, err)
 	}
 

--- a/internal/ledgerstore/alert_snooze.go
+++ b/internal/ledgerstore/alert_snooze.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/formancehq/reconciliation/internal/ledger"
 	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
 	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
 	"github.com/formancehq/reconciliation/internal/models"
@@ -14,8 +15,8 @@ import (
 )
 
 // SnoozeAlert mutes an active alert's notifications until `until`. Status-neutral
-// — no marker move, just the `snooze` metadata set on the item (a plain,
-// retransmit-safe LWW write). Re-snoozing overwrites the window. Rejects a
+// — no marker move. An activity transaction sets the `snooze` metadata on the
+// item and records the manual interaction atomically. Re-snoozing overwrites the window. Rejects a
 // non-future `until` and any non-active (RESOLVED) alert.
 func (s *LedgerStore) SnoozeAlert(ctx context.Context, id uuid.UUID, until time.Time, by, note string) (*models.Alert, error) {
 	now := time.Now().UTC()
@@ -40,16 +41,21 @@ func (s *LedgerStore) SnoozeAlert(ctx context.Context, id uuid.UUID, until time.
 	}
 
 	alert.Snooze = snooze
+	alert.UpdatedAt = now
 
 	// Status-neutral: prev == new. The snooze value and the transition record land
-	// in one metadata write, so the SAVED_METADATA event is self-describing.
-	md := map[string]*commonpb.MetadataValue{schema.MetaSnooze: strVal(string(b))}
+	// in one activity transaction, so the committed event is self-describing.
+	md := map[string]*commonpb.MetadataValue{schema.MetaSnooze: strVal(string(b)), schema.MetaUpdatedAt: dtVal(now)}
 	if err := stampTransition(md, transitionSnoozed, alert, alert.Status, "", now, map[string]any{"snooze": snooze}); err != nil {
 		return nil, fmt.Errorf("snooze alert %s: %w", id, err)
 	}
 
 	itemAddr := schema.AlertItemAccount(alert.RuleID.String(), alert.PeriodID, fpHash)
-	if err := s.client.SaveAccountMetadataValues(ctx, s.controlLedger, itemAddr, md); err != nil {
+	txmd, err := alertActivityMetadata(alert, md)
+	if err != nil {
+		return nil, fmt.Errorf("snooze alert %s activity: %w", id, err)
+	}
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(alert.RuleID.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{itemAddr: {Values: md}}, IdempotencyKey: alertActionKey("snooze", id.String(), until.UTC().Format(time.RFC3339Nano))}); err != nil {
 		return nil, fmt.Errorf("snooze alert %s: %w", id, err)
 	}
 
@@ -61,8 +67,7 @@ func (s *LedgerStore) SnoozeAlert(ctx context.Context, id uuid.UUID, until time.
 // already gone → the effect is done), which also makes a gRPC retransmit safe.
 //
 // The snooze delete and the self-describing transition record land in one atomic
-// batch, so `by` is now attributed (in the last_transition payload) — the
-// DELETED_METADATA event alone carries no actor.
+// activity transaction, so `by` is attributed in the history payload.
 func (s *LedgerStore) UnsnoozeAlert(ctx context.Context, id uuid.UUID, by string) (*models.Alert, error) {
 	alert, fpHash, err := s.loadAlertForTransition(ctx, id)
 	if err != nil {
@@ -76,12 +81,19 @@ func (s *LedgerStore) UnsnoozeAlert(ctx context.Context, id uuid.UUID, by string
 	// Status-neutral: prev == new. Record the transition (with the actor) and
 	// clear the snooze key atomically.
 	md := map[string]*commonpb.MetadataValue{}
-	if err := stampTransition(md, transitionUnsnoozed, alert, alert.Status, "", time.Now().UTC(), map[string]any{"by": by}); err != nil {
+	now := time.Now().UTC()
+	alert.UpdatedAt = now
+	md[schema.MetaUpdatedAt] = dtVal(now)
+	if err := stampTransition(md, transitionUnsnoozed, alert, alert.Status, "", now, map[string]any{"by": by}); err != nil {
 		return nil, fmt.Errorf("unsnooze alert %s: %w", id, err)
 	}
 
 	itemAddr := schema.AlertItemAccount(alert.RuleID.String(), alert.PeriodID, fpHash)
-	if err := s.client.ApplyMetadata(ctx, s.controlLedger, itemAddr, md, schema.MetaSnooze); err != nil && !isNotFound(err) {
+	txmd, err := alertActivityMetadata(alert, md)
+	if err != nil {
+		return nil, fmt.Errorf("unsnooze alert %s activity: %w", id, err)
+	}
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(alert.RuleID.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{itemAddr: {Values: md}}, DeleteMetadata: map[string][]string{itemAddr: {schema.MetaSnooze}}, IdempotencyKey: alertActionKey("unsnooze", id.String(), alert.Snooze.At.UTC().Format(time.RFC3339Nano))}); err != nil && !isNotFound(err) {
 		return nil, fmt.Errorf("unsnooze alert %s: %w", id, err)
 	}
 

--- a/internal/ledgerstore/alert_snooze_test.go
+++ b/internal/ledgerstore/alert_snooze_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
+	"github.com/formancehq/reconciliation/internal/ledger"
 	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
 	"github.com/formancehq/reconciliation/internal/models"
 	recstore "github.com/formancehq/reconciliation/internal/store"
@@ -24,17 +24,16 @@ func TestSnoozeAlert_SetsSnoozeMetadata(t *testing.T) {
 	a := activeAlert(models.AlertOpen)
 	expectFindByID(t, client, a, "1")
 
-	client.EXPECT().
-		SaveAccountMetadataValues(gomock.Any(), testControl, itemAddrOf(a), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, md map[string]*commonpb.MetadataValue) error {
-			// The snooze key + a self-describing transition record are written
-			// together (status-neutral, no marker move).
-			require.Contains(t, md, schema.MetaSnooze)
-			require.Contains(t, md, schema.MetaLastTransition)
-			require.Len(t, md, 2)
+	client.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tx ledger.CreateTransactionInput) error {
+		md := tx.AccountMetadata[itemAddrOf(a)].Values
+		// The snooze key + a self-describing transition record are written
+		// together (status-neutral, no marker move).
+		require.Contains(t, md, schema.MetaSnooze)
+		require.Contains(t, md, schema.MetaLastTransition)
+		require.Len(t, md, 3)
 
-			return nil
-		})
+		return nil
+	})
 
 	got, err := store.SnoozeAlert(context.Background(), a.ID, time.Now().Add(time.Hour), "ops", "on it")
 	require.NoError(t, err)
@@ -80,13 +79,13 @@ func TestUnsnoozeAlert_DeletesSnooze(t *testing.T) {
 
 	// Unsnooze records the transition (with the actor) and clears the snooze key
 	// in one atomic batch.
-	client.EXPECT().
-		ApplyMetadata(gomock.Any(), testControl, itemAddrOf(a), gomock.Any(), schema.MetaSnooze).
-		DoAndReturn(func(_ context.Context, _, _ string, set map[string]*commonpb.MetadataValue, _ ...string) error {
-			require.Contains(t, set, schema.MetaLastTransition)
+	client.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tx ledger.CreateTransactionInput) error {
+		set := tx.AccountMetadata[itemAddrOf(a)].Values
+		require.Contains(t, set, schema.MetaLastTransition)
+		require.Equal(t, []string{schema.MetaSnooze}, tx.DeleteMetadata[itemAddrOf(a)])
 
-			return nil
-		})
+		return nil
+	})
 
 	got, err := store.UnsnoozeAlert(context.Background(), a.ID, "ops")
 	require.NoError(t, err)

--- a/internal/ledgerstore/alert_test.go
+++ b/internal/ledgerstore/alert_test.go
@@ -35,7 +35,9 @@ func priorAccount(t *testing.T, a *models.Alert, occ string) *commonpb.Account {
 	return &commonpb.Account{
 		Address:  schema.AlertItemAccount(a.RuleID.String(), a.PeriodID, schema.FingerprintHash(a.Fingerprint)),
 		Metadata: md,
-		Volumes:  map[string]*commonpb.VolumesWithBalance{schema.AssetOcc: {Balance: occ}},
+		Volumes: []*commonpb.AccountVolume{
+			{Asset: schema.AssetOcc, Volumes: &commonpb.VolumesWithBalance{Balance: occ}},
+		},
 	}
 }
 

--- a/internal/ledgerstore/alert_test.go
+++ b/internal/ledgerstore/alert_test.go
@@ -24,6 +24,14 @@ const testControl = "recon-test"
 // account (so readAlertItem treats it as "no prior alert").
 func notFound() error { return status.Error(codes.NotFound, "account not found") }
 
+func TestUniqueActionKeyDoesNotReuseBusinessIdentity(t *testing.T) {
+	t.Parallel()
+
+	first := uniqueActionKey("rule-patch", "rule", "revision")
+	second := uniqueActionKey("rule-patch", "rule", "revision")
+	require.NotEqual(t, first, second)
+}
+
 // priorAccount builds the item-account snapshot GetAccount would return for an
 // existing alert with the given status/occurrence and optional closure state.
 func priorAccount(t *testing.T, a *models.Alert, occ string) *commonpb.Account {

--- a/internal/ledgerstore/alert_transition.go
+++ b/internal/ledgerstore/alert_transition.go
@@ -34,6 +34,7 @@ func (s *LedgerStore) AckAlert(ctx context.Context, id uuid.UUID, ack *models.Ac
 	prev := alert.Status
 	alert.Status = models.AlertAcknowledged
 	alert.Ack = ack
+	alert.UpdatedAt = ack.At
 
 	md, err := alertToMetadata(alert)
 	if err != nil {
@@ -98,6 +99,7 @@ func (s *LedgerStore) resolve(ctx context.Context, id uuid.UUID, resolution *mod
 	alert.Status = models.AlertResolved
 	alert.Resolution = resolution
 	alert.Snooze = nil
+	alert.UpdatedAt = resolution.At
 
 	md, err := alertToMetadata(alert)
 	if err != nil {
@@ -165,6 +167,7 @@ func (s *LedgerStore) AutoResolveAlert(ctx context.Context, ruleID uuid.UUID, fi
 	alert.Resolution = &models.Resolution{Kind: models.ResolutionAuto, By: "system", At: at}
 	alert.Snooze = nil
 	alert.LastEvaluationID = evaluationID
+	alert.UpdatedAt = at
 
 	md, err := alertToMetadata(alert)
 	if err != nil {
@@ -211,14 +214,21 @@ func (s *LedgerStore) moveMarker(ctx context.Context, alert *models.Alert, fpHas
 	rule := alert.RuleID.String()
 	itemAddr := schema.AlertItemAccount(rule, alert.PeriodID, fpHash)
 
+	txmd, err := alertActivityMetadata(alert, md)
+	if err != nil {
+		return err
+	}
 	return s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{
 		Ledger:        s.controlLedger,
 		ScriptName:    schema.NumscriptAlertMove,
 		ScriptVersion: schema.NumscriptVersion,
 		Vars: map[string]string{
-			schema.VarStFrom: schema.AlertStateAccount(fromState, rule, alert.PeriodID, fpHash),
-			schema.VarStTo:   toAddr,
+			schema.VarStFrom:       schema.AlertStateAccount(fromState, rule, alert.PeriodID, fpHash),
+			schema.VarStTo:         toAddr,
+			schema.VarActivityPool: schema.ActivityPool(rule),
+			schema.VarActivity:     schema.ActivityAccount(rule),
 		},
+		TxMetadata:      txmd,
 		AccountMetadata: map[string]*commonpb.MetadataMap{itemAddr: {Values: md}},
 		DeleteMetadata:  deletes,
 		IdempotencyKey:  key,

--- a/internal/ledgerstore/capture.go
+++ b/internal/ledgerstore/capture.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
@@ -20,32 +21,47 @@ import (
 // one evaluation (ADR-003): a self-describing snapshot (verdict, trigger, evidence)
 // on a COMMITTED_TRANSACTION plus a CAPTURE counter unit in the (rule, period)
 // bucket. The transaction is receipt-signed and append-only — the durable audit
-// record complementing the alert lifecycle (all failing evidence plus passing
-// evidence retained for automatic resolutions). Idempotent per (rule, period, evaluation): a gRPC
+// record complementing the alert lifecycle, with every evaluated outcome.
+// Idempotent per (rule, period, evaluation): a gRPC
 // retransmit dedups; a genuinely new evaluation gets a fresh key.
 func (s *LedgerStore) RecordCapture(ctx context.Context, in store.CaptureInput) error {
 	md := map[string]*commonpb.MetadataValue{
-		schema.CaptureMetaType: strVal(schema.CaptureType),
-		schema.CaptureMetaRule: strVal(in.RuleID.String()),
-		schema.CaptureMetaTmpl: strVal(in.TemplateKind),
-		schema.CaptureMetaPer:  strVal(in.PeriodID),
-		schema.CaptureMetaEval: strVal(in.EvaluationID.String()),
-		schema.CaptureMetaAt:   strVal(in.CapturedAt.UTC().Format(time.RFC3339Nano)),
-		schema.CaptureMetaVdt:  strVal(in.Verdict),
-		schema.CaptureMetaTrig: strVal(in.Trigger),
+		schema.CaptureMetaType:            strVal(schema.CaptureType),
+		schema.CaptureMetaRule:            strVal(in.RuleID.String()),
+		schema.CaptureMetaTmpl:            strVal(in.TemplateKind),
+		schema.CaptureMetaPer:             strVal(in.PeriodID),
+		schema.CaptureMetaEval:            strVal(in.EvaluationID.String()),
+		schema.CaptureMetaAt:              strVal(in.CapturedAt.UTC().Format(time.RFC3339Nano)),
+		schema.CaptureMetaVdt:             strVal(in.Verdict),
+		schema.CaptureMetaTrig:            strVal(in.Trigger),
+		schema.CaptureMetaContractVersion: strVal(strconv.Itoa(int(in.ContractVersion.Effective()))),
+		schema.CaptureMetaRevision:        strVal(in.RuleRevision),
+		schema.CaptureMetaStartedAt:       strVal(in.StartedAt.UTC().Format(time.RFC3339Nano)),
+		schema.CaptureMetaPIT:             strVal(in.PIT.UTC().Format(time.RFC3339Nano)),
+		schema.CaptureMetaResult:          strVal(string(in.Result)),
+		schema.CaptureMetaError:           strVal(in.Error),
 	}
 	if len(in.Evidence) > 0 {
 		md[schema.CaptureMetaEvi] = strVal(string(in.Evidence))
 	}
 
 	rule := in.RuleID.String()
+	activity, err := activityMetadata("evaluation.completed", in.RuleID, in.ContractVersion, in.RuleRevision, in.EvaluationID.String(), in.CapturedAt, in)
+	if err != nil {
+		return fmt.Errorf("record capture activity: %w", err)
+	}
+	for k, v := range activity {
+		md[k] = v
+	}
 	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{
 		Ledger:        s.controlLedger,
 		ScriptName:    schema.NumscriptCapture,
 		ScriptVersion: schema.NumscriptVersion,
 		Vars: map[string]string{
-			schema.VarCapturePool: schema.CapturePool(rule),
-			schema.VarCapture:     schema.CaptureAccount(rule, in.PeriodID),
+			schema.VarCapturePool:  schema.CapturePool(rule),
+			schema.VarCapture:      schema.CaptureAccount(rule, in.PeriodID),
+			schema.VarActivityPool: schema.ActivityPool(rule),
+			schema.VarActivity:     schema.ActivityAccount(rule),
 		},
 		TxMetadata:     md,
 		IdempotencyKey: alertActionKey("capture", rule, in.PeriodID, in.EvaluationID.String()),
@@ -76,6 +92,9 @@ func (s *LedgerStore) ListCaptures(ctx context.Context, ruleID uuid.UUID, q stor
 	captures := make([]models.Capture, 0, 64)
 	if err := s.client.ListTransactionsFunc(ctx, s.controlLedger, schema.FilterAddressPrefix(prefix), func(tx *commonpb.Transaction) error {
 		if c, ok := captureFromTransaction(tx); ok {
+			if version := q.Options.Options.ContractVersion; version != nil && c.ContractVersion.Effective() != *version {
+				return nil
+			}
 			captures = append(captures, c)
 		}
 
@@ -109,11 +128,18 @@ func captureFromTransaction(tx *commonpb.Transaction) (models.Capture, bool) {
 	}
 
 	c := models.Capture{
-		TransactionID: tx.GetId(),
-		PeriodID:      getStr(md, schema.CaptureMetaPer),
-		TemplateKind:  getStr(md, schema.CaptureMetaTmpl),
-		Verdict:       getStr(md, schema.CaptureMetaVdt),
-		Trigger:       getStr(md, schema.CaptureMetaTrig),
+		TransactionID:   tx.GetId(),
+		ContractVersion: models.ContractVersionV1,
+		PeriodID:        getStr(md, schema.CaptureMetaPer),
+		TemplateKind:    getStr(md, schema.CaptureMetaTmpl),
+		Verdict:         getStr(md, schema.CaptureMetaVdt),
+		Trigger:         getStr(md, schema.CaptureMetaTrig),
+		RuleRevision:    getStr(md, schema.CaptureMetaRevision),
+		Result:          models.EvaluationResult(getStr(md, schema.CaptureMetaResult)),
+		Error:           getStr(md, schema.CaptureMetaError),
+	}
+	if version, err := strconv.Atoi(getStr(md, schema.CaptureMetaContractVersion)); err == nil && version > 0 {
+		c.ContractVersion = models.ContractVersion(version)
 	}
 
 	if id, err := uuid.Parse(getStr(md, schema.CaptureMetaRule)); err == nil {
@@ -126,6 +152,12 @@ func captureFromTransaction(tx *commonpb.Transaction) (models.Capture, bool) {
 
 	if t, err := time.Parse(time.RFC3339Nano, getStr(md, schema.CaptureMetaAt)); err == nil {
 		c.CapturedAt = t.UTC()
+	}
+	if t, err := time.Parse(time.RFC3339Nano, getStr(md, schema.CaptureMetaStartedAt)); err == nil {
+		c.StartedAt = t.UTC()
+	}
+	if t, err := time.Parse(time.RFC3339Nano, getStr(md, schema.CaptureMetaPIT)); err == nil {
+		c.PIT = t.UTC()
 	}
 
 	if ev := getStr(md, schema.CaptureMetaEvi); ev != "" {

--- a/internal/ledgerstore/capture_test.go
+++ b/internal/ledgerstore/capture_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
 	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
+	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/store"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -50,6 +51,13 @@ func TestCaptureFromTransaction_RoundTrip(t *testing.T) {
 	require.Equal(t, "scheduled", c.Trigger)
 	require.True(t, at.Equal(c.CapturedAt), "captured_at round-trips")
 	require.JSONEq(t, `{"delta":"5"}`, string(c.Evidence))
+	require.Equal(t, models.ContractVersionV1, c.ContractVersion, "legacy captures default to V1")
+
+	v2tx := captureTx(8, ruleID, "2026-03", evalID.String(), "fail", "scheduled", at, `{}`)
+	v2tx.Metadata[schema.CaptureMetaContractVersion] = strVal("2")
+	v2, ok := captureFromTransaction(v2tx)
+	require.True(t, ok)
+	require.Equal(t, models.ContractVersionV2, v2.ContractVersion)
 }
 
 func TestCaptureFromTransaction_NotACapture(t *testing.T) {

--- a/internal/ledgerstore/list_test.go
+++ b/internal/ledgerstore/list_test.go
@@ -85,6 +85,26 @@ func TestListRules_SecondPage(t *testing.T) {
 	require.NotEmpty(t, page.Previous)
 }
 
+func TestListRules_FiltersContractBeforePagination(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	client := NewMockledgerClient(ctrl)
+	store := New(client, testControl)
+	base := time.Now().Truncate(time.Microsecond).UTC()
+	v1 := &models.Rule{ID: uuid.New(), Name: "v1", ContractVersion: models.ContractVersionV1, CreatedAt: base.Add(-time.Hour), UpdatedAt: base}
+	v2 := &models.Rule{ID: uuid.New(), Name: "v2-newest", ContractVersion: models.ContractVersionV2, CreatedAt: base, UpdatedAt: base}
+	client.EXPECT().QueryAccounts(gomock.Any(), testControl, gomock.Any()).Return([]*commonpb.Account{ruleAccount(t, v2), ruleAccount(t, v1)}, nil)
+
+	version := models.ContractVersionV1
+	q := recstore.NewGetRulesQuery(recstore.NewPaginatedQueryOptions(recstore.RulesFilters{ContractVersion: &version}).WithPageSize(1))
+	page, err := store.ListRules(context.Background(), q)
+	require.NoError(t, err)
+	require.Len(t, page.Data, 1)
+	require.Equal(t, "v1", page.Data[0].Name)
+	require.False(t, page.HasMore)
+}
+
 func TestListAlerts_SortedByLastSeen(t *testing.T) {
 	t.Parallel()
 
@@ -111,6 +131,26 @@ func TestListAlerts_SortedByLastSeen(t *testing.T) {
 	require.Len(t, page.Data, 2)
 	require.Equal(t, "fp-fresh", page.Data[0].Fingerprint, "most-recently-seen first")
 	require.Equal(t, "fp-old", page.Data[1].Fingerprint)
+	require.False(t, page.HasMore)
+}
+
+func TestListAlerts_FiltersContractBeforePagination(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	client := NewMockledgerClient(ctrl)
+	store := New(client, testControl)
+	base := time.Now().Truncate(time.Microsecond).UTC()
+	v1 := &models.Alert{ID: uuid.New(), RuleID: uuid.New(), Fingerprint: "v1", ContractVersion: models.ContractVersionV1, PeriodID: "continuous", Status: models.AlertOpen, LastSeenAt: base.Add(-time.Hour), CreatedAt: base}
+	v2 := &models.Alert{ID: uuid.New(), RuleID: uuid.New(), Fingerprint: "v2-newest", ContractVersion: models.ContractVersionV2, PeriodID: "continuous", Status: models.AlertOpen, LastSeenAt: base, CreatedAt: base}
+	client.EXPECT().QueryAccounts(gomock.Any(), testControl, gomock.Any()).Return([]*commonpb.Account{priorAccount(t, v2, "1"), priorAccount(t, v1, "1")}, nil)
+
+	version := models.ContractVersionV1
+	q := recstore.NewGetAlertsQuery(recstore.NewPaginatedQueryOptions(recstore.AlertsFilters{ContractVersion: &version}).WithPageSize(1))
+	page, err := store.ListAlerts(context.Background(), q)
+	require.NoError(t, err)
+	require.Len(t, page.Data, 1)
+	require.Equal(t, "v1", page.Data[0].Fingerprint)
 	require.False(t, page.HasMore)
 }
 

--- a/internal/ledgerstore/metadata.go
+++ b/internal/ledgerstore/metadata.go
@@ -3,6 +3,7 @@ package ledgerstore
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
@@ -43,19 +44,29 @@ func getTime(md map[string]*commonpb.MetadataValue, key string) time.Time {
 	return time.UnixMicro(v.GetDatetimeValue()).UTC()
 }
 
+func getContractVersion(md map[string]*commonpb.MetadataValue) models.ContractVersion {
+	v, err := strconv.Atoi(getStr(md, schema.MetaContractVersion))
+	if err != nil || v == 0 {
+		return models.ContractVersionV1
+	}
+	return models.ContractVersion(v)
+}
+
 // --- Rule <-> metadata ---
 
 // ruleToMetadata serialises a Rule to the typed control-ledger metadata map.
 func ruleToMetadata(r *models.Rule) (map[string]*commonpb.MetadataValue, error) {
 	md := map[string]*commonpb.MetadataValue{
-		schema.MetaName:         strVal(r.Name),
-		schema.MetaTemplateKind: strVal(string(r.TemplateKind)),
-		schema.MetaSpec:         strVal(string(r.TemplateSpec)),
-		schema.MetaEnabled:      boolVal(r.Enabled),
-		schema.MetaSeverity:     strVal(string(r.Severity)),
-		schema.MetaCadence:      strVal(string(r.Cadence)),
-		schema.MetaCreatedAt:    dtVal(r.CreatedAt),
-		schema.MetaUpdatedAt:    dtVal(r.UpdatedAt),
+		schema.MetaName:            strVal(r.Name),
+		schema.MetaTemplateKind:    strVal(string(r.TemplateKind)),
+		schema.MetaSpec:            strVal(string(r.TemplateSpec)),
+		schema.MetaEnabled:         boolVal(r.Enabled),
+		schema.MetaSeverity:        strVal(string(r.Severity)),
+		schema.MetaCadence:         strVal(string(r.Cadence)),
+		schema.MetaCreatedAt:       dtVal(r.CreatedAt),
+		schema.MetaUpdatedAt:       dtVal(r.UpdatedAt),
+		schema.MetaContractVersion: strVal(strconv.Itoa(int(r.ContractVersion.Effective()))),
+		schema.MetaRevision:        strVal(r.Revision),
 	}
 
 	if r.CompiledCEL != "" {
@@ -98,16 +109,18 @@ func ruleFromAccount(acct *commonpb.Account) (*models.Rule, error) {
 	md := acct.GetMetadata()
 
 	r := &models.Rule{
-		ID:           id,
-		Name:         getStr(md, schema.MetaName),
-		TemplateKind: models.TemplateKind(getStr(md, schema.MetaTemplateKind)),
-		TemplateSpec: json.RawMessage(getStr(md, schema.MetaSpec)),
-		CompiledCEL:  getStr(md, schema.MetaCompiledCEL),
-		Enabled:      getBool(md, schema.MetaEnabled),
-		Severity:     models.Severity(getStr(md, schema.MetaSeverity)),
-		Cadence:      models.Cadence(getStr(md, schema.MetaCadence)),
-		CreatedAt:    getTime(md, schema.MetaCreatedAt),
-		UpdatedAt:    getTime(md, schema.MetaUpdatedAt),
+		ID:              id,
+		ContractVersion: getContractVersion(md),
+		Revision:        getStr(md, schema.MetaRevision),
+		Name:            getStr(md, schema.MetaName),
+		TemplateKind:    models.TemplateKind(getStr(md, schema.MetaTemplateKind)),
+		TemplateSpec:    json.RawMessage(getStr(md, schema.MetaSpec)),
+		CompiledCEL:     getStr(md, schema.MetaCompiledCEL),
+		Enabled:         getBool(md, schema.MetaEnabled),
+		Severity:        models.Severity(getStr(md, schema.MetaSeverity)),
+		Cadence:         models.Cadence(getStr(md, schema.MetaCadence)),
+		CreatedAt:       getTime(md, schema.MetaCreatedAt),
+		UpdatedAt:       getTime(md, schema.MetaUpdatedAt),
 	}
 
 	if s := getStr(md, schema.MetaSchedule); s != "" {
@@ -132,6 +145,12 @@ func ruleFromAccount(acct *commonpb.Account) (*models.Rule, error) {
 			}
 
 			r.Labels[label] = v.GetStringValue()
+		}
+	}
+	if r.Revision == "" {
+		r.Revision, err = ruleRevision(r)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/ledgerstore/metadata_test.go
+++ b/internal/ledgerstore/metadata_test.go
@@ -91,3 +91,25 @@ func TestRuleMetadataMinimal(t *testing.T) {
 	require.Empty(t, got.Labels)
 	require.False(t, got.Enabled)
 }
+
+func TestRuleMetadataContractVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	legacy := &commonpb.Account{
+		Address:  schema.RuleAccount(id.String()),
+		Metadata: map[string]*commonpb.MetadataValue{},
+	}
+	got, err := ruleFromAccount(legacy)
+	require.NoError(t, err)
+	require.Equal(t, models.ContractVersionV1, got.ContractVersion)
+
+	rule := &models.Rule{ID: id, ContractVersion: models.ContractVersionV2}
+	md, err := ruleToMetadata(rule)
+	require.NoError(t, err)
+	require.Equal(t, "2", md[schema.MetaContractVersion].GetStringValue())
+
+	got, err = ruleFromAccount(&commonpb.Account{Address: schema.RuleAccount(id.String()), Metadata: md})
+	require.NoError(t, err)
+	require.Equal(t, models.ContractVersionV2, got.ContractVersion)
+}

--- a/internal/ledgerstore/rule.go
+++ b/internal/ledgerstore/rule.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/formancehq/go-libs/bun/bunpaginate"
+	"github.com/formancehq/reconciliation/internal/ledger"
+	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
 	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
 	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/formancehq/reconciliation/internal/store"
@@ -23,12 +25,26 @@ import (
 // collisions do not occur in practice; a guarded create would cost a
 // read-before-write round-trip on every call. See migration log F13.
 func (s *LedgerStore) CreateRule(ctx context.Context, r *models.Rule) error {
+	if r.CreatedAt.IsZero() {
+		r.CreatedAt = time.Now().UTC()
+	}
+	if r.UpdatedAt.IsZero() {
+		r.UpdatedAt = r.CreatedAt
+	}
+	revision, err := ruleRevision(r)
+	if err != nil {
+		return fmt.Errorf("create rule %s revision: %w", r.ID, err)
+	}
+	r.Revision = revision
 	md, err := ruleToMetadata(r)
 	if err != nil {
 		return fmt.Errorf("create rule %s: %w", r.ID, err)
 	}
-
-	if err := s.client.SaveAccountMetadataValues(ctx, s.controlLedger, schema.RuleAccount(r.ID.String()), md); err != nil {
+	txmd, err := activityMetadata("rule.created", r.ID, r.ContractVersion, r.Revision, "", r.CreatedAt, map[string]any{"snapshot": r})
+	if err != nil {
+		return fmt.Errorf("create rule %s event: %w", r.ID, err)
+	}
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(r.ID.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{schema.RuleAccount(r.ID.String()): {Values: md}}, IdempotencyKey: alertActionKey("rule-create", r.ID.String())}); err != nil {
 		return fmt.Errorf("create rule %s: %w", r.ID, err)
 	}
 
@@ -69,24 +85,34 @@ func (s *LedgerStore) PatchRule(ctx context.Context, id uuid.UUID, patch store.R
 	}
 
 	oldLabels := rule.Labels
+	previousRevision := rule.Revision
 	applyRulePatch(rule, patch)
 	rule.UpdatedAt = time.Now().UTC()
+	rule.Revision, err = ruleRevision(rule)
+	if err != nil {
+		return fmt.Errorf("patch rule %s revision: %w", id, err)
+	}
+	if rule.Revision == previousRevision {
+		return nil
+	}
 
 	md, err := ruleToMetadata(rule)
 	if err != nil {
 		return fmt.Errorf("patch rule %s: %w", id, err)
 	}
 
-	if err := s.client.SaveAccountMetadataValues(ctx, s.controlLedger, schema.RuleAccount(id.String()), md); err != nil {
-		return fmt.Errorf("patch rule %s: %w", id, err)
-	}
-
+	var deletes map[string][]string
 	if patch.Labels != nil {
 		if removed := removedLabelKeys(oldLabels, rule.Labels); len(removed) > 0 {
-			if err := s.client.DeleteAccountMetadata(ctx, s.controlLedger, schema.RuleAccount(id.String()), removed...); err != nil {
-				return fmt.Errorf("patch rule %s: prune labels: %w", id, err)
-			}
+			deletes = map[string][]string{schema.RuleAccount(id.String()): removed}
 		}
+	}
+	txmd, err := activityMetadata("rule.updated", id, rule.ContractVersion, rule.Revision, "", rule.UpdatedAt, map[string]any{"previousRevision": previousRevision, "snapshot": rule})
+	if err != nil {
+		return fmt.Errorf("patch rule %s event: %w", id, err)
+	}
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(id.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{schema.RuleAccount(id.String()): {Values: md}}, DeleteMetadata: deletes, IdempotencyKey: alertActionKey("rule-patch", id.String(), rule.Revision)}); err != nil {
+		return fmt.Errorf("patch rule %s: %w", id, err)
 	}
 
 	return nil
@@ -113,7 +139,16 @@ func (s *LedgerStore) DeleteRule(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("delete rule %s: %w", id, store.ErrNotFound)
 	}
 
-	if err := s.client.DeleteAccountMetadata(ctx, s.controlLedger, schema.RuleAccount(id.String()), keys...); err != nil {
+	rule, err := ruleFromAccount(acct)
+	if err != nil {
+		return fmt.Errorf("delete rule %s: decode: %w", id, err)
+	}
+	at := time.Now().UTC()
+	txmd, err := activityMetadata("rule.deleted", id, rule.ContractVersion, rule.Revision, "", at, map[string]any{"snapshot": rule})
+	if err != nil {
+		return fmt.Errorf("delete rule %s event: %w", id, err)
+	}
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(id.String()), TxMetadata: txmd, DeleteMetadata: map[string][]string{schema.RuleAccount(id.String()): keys}, IdempotencyKey: alertActionKey("rule-delete", id.String(), rule.Revision)}); err != nil {
 		return fmt.Errorf("delete rule %s: %w", id, err)
 	}
 
@@ -143,7 +178,9 @@ func (s *LedgerStore) ListRules(ctx context.Context, q store.GetRulesQuery) (*bu
 			return nil, fmt.Errorf("list rules: decode %s: %w", acct.GetAddress(), derr)
 		}
 
-		rules = append(rules, *r)
+		if version := q.Options.Options.ContractVersion; version == nil || r.ContractVersion.Effective() == *version {
+			rules = append(rules, *r)
+		}
 	}
 
 	slices.SortFunc(rules, func(a, b models.Rule) int { return b.CreatedAt.Compare(a.CreatedAt) })

--- a/internal/ledgerstore/rule.go
+++ b/internal/ledgerstore/rule.go
@@ -111,7 +111,7 @@ func (s *LedgerStore) PatchRule(ctx context.Context, id uuid.UUID, patch store.R
 	if err != nil {
 		return fmt.Errorf("patch rule %s event: %w", id, err)
 	}
-	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(id.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{schema.RuleAccount(id.String()): {Values: md}}, DeleteMetadata: deletes, IdempotencyKey: alertActionKey("rule-patch", id.String(), rule.Revision)}); err != nil {
+	if err := s.client.CreateTransaction(ctx, ledger.CreateTransactionInput{Ledger: s.controlLedger, ScriptName: schema.NumscriptActivity, ScriptVersion: schema.NumscriptVersion, Vars: activityVars(id.String()), TxMetadata: txmd, AccountMetadata: map[string]*commonpb.MetadataMap{schema.RuleAccount(id.String()): {Values: md}}, DeleteMetadata: deletes, IdempotencyKey: uniqueActionKey("rule-patch", id.String(), rule.Revision)}); err != nil {
 		return fmt.Errorf("patch rule %s: %w", id, err)
 	}
 

--- a/internal/ledgerstore/rule_test.go
+++ b/internal/ledgerstore/rule_test.go
@@ -3,10 +3,10 @@ package ledgerstore
 import (
 	"context"
 	"encoding/json"
-	"slices"
 	"testing"
 	"time"
 
+	"github.com/formancehq/reconciliation/internal/ledger"
 	"github.com/formancehq/reconciliation/internal/ledgerpb/commonpb"
 	schema "github.com/formancehq/reconciliation/internal/ledgerschema"
 	"github.com/formancehq/reconciliation/internal/models"
@@ -55,14 +55,13 @@ func TestLedgerStore_CreateRule(t *testing.T) {
 	m := NewMockledgerClient(ctrl)
 	id := uuid.New()
 
-	m.EXPECT().
-		SaveAccountMetadataValues(gomock.Any(), controlLedger, schema.RuleAccount(id.String()), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, md map[string]*commonpb.MetadataValue) error {
-			require.Equal(t, "r", md[schema.MetaName].GetStringValue())
-			require.True(t, md[schema.MetaEnabled].GetBoolValue())
-
-			return nil
-		})
+	m.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tx ledger.CreateTransactionInput) error {
+		md := tx.AccountMetadata[schema.RuleAccount(id.String())].Values
+		require.Equal(t, "r", md[schema.MetaName].GetStringValue())
+		require.True(t, md[schema.MetaEnabled].GetBoolValue())
+		require.Equal(t, "rule.created", tx.TxMetadata[schema.ActivityMetaKind].GetStringValue())
+		return nil
+	})
 
 	require.NoError(t, New(m, controlLedger).CreateRule(context.Background(), newRule(id)))
 }
@@ -126,13 +125,13 @@ func TestLedgerStore_PatchRule(t *testing.T) {
 	m.EXPECT().
 		GetAccount(gomock.Any(), controlLedger, schema.RuleAccount(id.String())).
 		Return(account(t, newRule(id)), nil)
-	m.EXPECT().
-		SaveAccountMetadataValues(gomock.Any(), controlLedger, schema.RuleAccount(id.String()), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, md map[string]*commonpb.MetadataValue) error {
-			require.Equal(t, "renamed", md[schema.MetaName].GetStringValue())
-			require.False(t, md[schema.MetaEnabled].GetBoolValue()) // patched to false
-			return nil
-		})
+	m.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tx ledger.CreateTransactionInput) error {
+		md := tx.AccountMetadata[schema.RuleAccount(id.String())].Values
+		require.Equal(t, "renamed", md[schema.MetaName].GetStringValue())
+		require.False(t, md[schema.MetaEnabled].GetBoolValue()) // patched to false
+		require.Equal(t, "rule.updated", tx.TxMetadata[schema.ActivityMetaKind].GetStringValue())
+		return nil
+	})
 
 	err := New(m, controlLedger).PatchRule(context.Background(), id, store.RulePatch{
 		Name:    ptr("renamed"),
@@ -152,14 +151,10 @@ func TestLedgerStore_PatchRule_PrunesRemovedLabels(t *testing.T) {
 	base.Labels = map[string]string{"env": "prod", "team": "treasury"}
 
 	m.EXPECT().GetAccount(gomock.Any(), controlLedger, schema.RuleAccount(id.String())).Return(account(t, base), nil)
-	m.EXPECT().SaveAccountMetadataValues(gomock.Any(), controlLedger, schema.RuleAccount(id.String()), gomock.Any()).Return(nil)
-	// "team" was removed -> its label key must be deleted.
-	m.EXPECT().
-		DeleteAccountMetadata(gomock.Any(), controlLedger, schema.RuleAccount(id.String()), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, keys ...string) error {
-			require.Equal(t, []string{schema.LabelPrefix + "team"}, keys)
-			return nil
-		})
+	m.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tx ledger.CreateTransactionInput) error {
+		require.Equal(t, []string{schema.LabelPrefix + "team"}, tx.DeleteMetadata[schema.RuleAccount(id.String())])
+		return nil
+	})
 
 	err := New(m, controlLedger).PatchRule(context.Background(), id, store.RulePatch{
 		Labels: ptr(map[string]string{"env": "prod"}),
@@ -175,13 +170,11 @@ func TestLedgerStore_DeleteRule(t *testing.T) {
 	id := uuid.New()
 
 	m.EXPECT().GetAccount(gomock.Any(), controlLedger, schema.RuleAccount(id.String())).Return(account(t, newRule(id)), nil)
-	m.EXPECT().
-		DeleteAccountMetadata(gomock.Any(), controlLedger, schema.RuleAccount(id.String()), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, keys ...string) error {
-			require.NotEmpty(t, keys)
-			require.True(t, slices.Contains(keys, schema.MetaName))
-			return nil
-		})
+	m.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, tx ledger.CreateTransactionInput) error {
+		require.NotEmpty(t, tx.DeleteMetadata[schema.RuleAccount(id.String())])
+		require.Equal(t, "rule.deleted", tx.TxMetadata[schema.ActivityMetaKind].GetStringValue())
+		return nil
+	})
 
 	require.NoError(t, New(m, controlLedger).DeleteRule(context.Background(), id))
 }

--- a/internal/ledgerstore/store_it_test.go
+++ b/internal/ledgerstore/store_it_test.go
@@ -205,10 +205,14 @@ func TestIntegration_OpenAlert(t *testing.T) {
 	// as a key/content conflict rather than replaying (see migration log F17).
 	probe := schema.AlertItemAccount(ruleID.String(), period, schema.FingerprintHash("idem-probe"))
 	occMint := ledger.CreateTransactionInput{
-		Ledger:         control,
-		ScriptName:     schema.NumscriptAlertBump,
-		ScriptVersion:  schema.NumscriptVersion,
-		Vars:           map[string]string{schema.VarPool: poolAddr, schema.VarItem: probe},
+		Ledger:        control,
+		ScriptName:    schema.NumscriptAlertBump,
+		ScriptVersion: schema.NumscriptVersion,
+		Vars: map[string]string{
+			schema.VarPool: poolAddr, schema.VarItem: probe,
+			schema.VarActivityPool: schema.ActivityPool(ruleID.String()),
+			schema.VarActivity:     schema.ActivityAccount(ruleID.String()),
+		},
 		IdempotencyKey: "it-idem-" + ruleID.String(),
 	}
 	require.NoError(t, client.CreateTransaction(ctx, occMint))
@@ -567,7 +571,7 @@ func balance(ctx context.Context, t *testing.T, c *ledger.Client, ledgerName, ad
 	acct, err := c.GetAccount(ctx, ledgerName, addr)
 	require.NoError(t, err, "get account %s", addr)
 
-	return acct.GetVolumes()[asset].GetBalance()
+	return commonpb.BalanceByAsset(acct, asset).String()
 }
 
 // balanceOrZero reads an asset balance, treating a purged (NotFound) account or
@@ -582,8 +586,8 @@ func balanceOrZero(ctx context.Context, t *testing.T, c *ledger.Client, ledgerNa
 
 	require.NoError(t, err, "get account %s", addr)
 
-	if bal := acct.GetVolumes()[asset].GetBalance(); bal != "" {
-		return bal
+	if bal := commonpb.BalanceByAsset(acct, asset); bal.Sign() != 0 {
+		return bal.String()
 	}
 
 	return "0"

--- a/internal/ledgerstore/transition_event.go
+++ b/internal/ledgerstore/transition_event.go
@@ -72,3 +72,12 @@ func stampTransition(md map[string]*commonpb.MetadataValue, t transitionType, a 
 
 	return nil
 }
+
+func alertActivityMetadata(a *models.Alert, md map[string]*commonpb.MetadataValue) (map[string]*commonpb.MetadataValue, error) {
+	var env transitionEvent
+	if err := json.Unmarshal([]byte(getStr(md, schema.MetaLastTransition)), &env); err != nil {
+		return nil, err
+	}
+	kind := "alert." + string(env.Type[len(transitionEventTypePrefix):])
+	return activityMetadata(kind, a.RuleID, a.ContractVersion, "", env.CorrelationID, env.OccurredAt, env)
+}

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// RuleActivity is one immutable, ordered fact in a rule's combined history.
+type RuleActivity struct {
+	ID              string          `json:"id"`
+	Sequence        string          `json:"sequence"`
+	Kind            string          `json:"kind"`
+	Category        string          `json:"category"`
+	RuleID          uuid.UUID       `json:"ruleID"`
+	ContractVersion ContractVersion `json:"contractVersion"`
+	RuleRevision    string          `json:"ruleRevision,omitempty"`
+	CorrelationID   string          `json:"correlationID,omitempty"`
+	OccurredAt      time.Time       `json:"occurredAt"`
+	RecordedAt      time.Time       `json:"recordedAt"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+}

--- a/internal/models/alert.go
+++ b/internal/models/alert.go
@@ -99,9 +99,10 @@ type Resolution struct {
 type Alert struct {
 	bun.BaseModel `bun:"reconciliations.alert" json:"-"`
 
-	ID          uuid.UUID `bun:",pk,nullzero"                  json:"id"`
-	RuleID      uuid.UUID `bun:"rule_id,notnull"               json:"ruleID"`
-	Fingerprint string    `bun:",notnull"                      json:"fingerprint"`
+	ID              uuid.UUID       `bun:",pk,nullzero"                  json:"id"`
+	ContractVersion ContractVersion `bun:"-" json:"-"`
+	RuleID          uuid.UUID       `bun:"rule_id,notnull"               json:"ruleID"`
+	Fingerprint     string          `bun:",notnull"                      json:"fingerprint"`
 	// PeriodID scopes the alert to a reconciliation period (e.g. "2026-03",
 	// or "continuous" for a live-monitoring rule). The dedup identity is
 	// (rule_id, fingerprint, period_id): a new period opens a fresh case

--- a/internal/models/capture.go
+++ b/internal/models/capture.go
@@ -10,8 +10,8 @@ import (
 // Capture is one immutable evaluation record read back from the control ledger
 // (ADR-003). Every rule evaluation mints a capture transaction in the
 // `capture:rule:{ruleID}:per:{period}` bucket carrying this self-describing
-// snapshot. Its bounded evidence contains every failing outcome plus passing
-// outcomes that resolved active alerts. It is reconstructed from the capture
+// snapshot. Its evidence contains every outcome and the exact values used by
+// that evaluation. It is reconstructed from the capture
 // transaction's metadata plus its ledger id.
 //
 // Unlike an AlertEvent (the alert transition timeline, sink-gated), a Capture is
@@ -20,13 +20,19 @@ import (
 type Capture struct {
 	// TransactionID is the ledger-local id of the capture transaction — a stable
 	// handle for the record within the control ledger.
-	TransactionID uint64          `json:"transactionID"`
-	RuleID        uuid.UUID       `json:"ruleID"`
-	PeriodID      string          `json:"periodID"`
-	EvaluationID  uuid.UUID       `json:"evaluationID"`
-	TemplateKind  string          `json:"templateKind"`
-	Verdict       string          `json:"verdict"` // "pass" | "fail"
-	Trigger       string          `json:"trigger"` // "scheduled" | "manual"
-	CapturedAt    time.Time       `json:"capturedAt"`
-	Evidence      json.RawMessage `json:"evidence,omitempty"`
+	TransactionID   uint64           `json:"transactionID"`
+	ContractVersion ContractVersion  `json:"-"`
+	RuleID          uuid.UUID        `json:"ruleID"`
+	PeriodID        string           `json:"periodID"`
+	EvaluationID    uuid.UUID        `json:"evaluationID"`
+	TemplateKind    string           `json:"templateKind"`
+	Verdict         string           `json:"verdict"` // "pass" | "fail"
+	Trigger         string           `json:"trigger"` // "scheduled" | "manual"
+	CapturedAt      time.Time        `json:"capturedAt"`
+	Evidence        json.RawMessage  `json:"evidence,omitempty"`
+	RuleRevision    string           `json:"ruleRevision,omitempty"`
+	PIT             time.Time        `json:"pit,omitempty"`
+	StartedAt       time.Time        `json:"startedAt,omitempty"`
+	Result          EvaluationResult `json:"result,omitempty"`
+	Error           string           `json:"error,omitempty"`
 }

--- a/internal/models/evaluation.go
+++ b/internal/models/evaluation.go
@@ -27,13 +27,14 @@ const (
 type Evaluation struct {
 	bun.BaseModel `bun:"reconciliations.evaluation" json:"-"`
 
-	ID        uuid.UUID        `bun:",pk,nullzero"                 json:"id"`
-	RuleID    uuid.UUID        `bun:"rule_id,notnull"              json:"ruleID"`
-	StartedAt time.Time        `bun:"started_at,notnull,nullzero"  json:"startedAt"`
-	EndedAt   time.Time        `bun:"ended_at,notnull,nullzero"    json:"endedAt"`
-	Result    EvaluationResult `bun:",notnull"                     json:"result"`
-	Evidence  json.RawMessage  `bun:",type:jsonb"                  json:"evidence,omitempty"`
-	Error     string           `bun:",nullzero"                    json:"error,omitempty"`
-	CostUnits int64            `bun:"cost_units,notnull"           json:"costUnits"`
-	CreatedAt time.Time        `bun:"created_at,notnull,nullzero"  json:"createdAt"`
+	ID              uuid.UUID        `bun:",pk,nullzero"                 json:"id"`
+	ContractVersion ContractVersion  `bun:"-" json:"-"`
+	RuleID          uuid.UUID        `bun:"rule_id,notnull"              json:"ruleID"`
+	StartedAt       time.Time        `bun:"started_at,notnull,nullzero"  json:"startedAt"`
+	EndedAt         time.Time        `bun:"ended_at,notnull,nullzero"    json:"endedAt"`
+	Result          EvaluationResult `bun:",notnull"                     json:"result"`
+	Evidence        json.RawMessage  `bun:",type:jsonb"                  json:"evidence,omitempty"`
+	Error           string           `bun:",nullzero"                    json:"error,omitempty"`
+	CostUnits       int64            `bun:"cost_units,notnull"           json:"costUnits"`
+	CreatedAt       time.Time        `bun:"created_at,notnull,nullzero"  json:"createdAt"`
 }

--- a/internal/models/rule.go
+++ b/internal/models/rule.go
@@ -9,9 +9,26 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// TemplateKind is the V1 public-API surface for rules — a typed catalog entry
-// that compiles deterministically to an internal CEL expression. The kernel is
-// not exposed at V1 GA; templates are the entire customer-facing surface.
+// ContractVersion identifies the public HTTP contract that owns a persisted
+// rule and all evidence derived from it. It is immutable for the lifetime of a
+// rule. Records written before the field existed are V1.
+type ContractVersion int
+
+const (
+	ContractVersionV1 ContractVersion = 1
+	ContractVersionV2 ContractVersion = 2
+)
+
+func (v ContractVersion) Effective() ContractVersion {
+	if v == 0 {
+		return ContractVersionV1
+	}
+	return v
+}
+
+// TemplateKind identifies a typed catalog entry that compiles deterministically
+// to an internal CEL expression. Contract-version validation controls which
+// entries are available through V1 and V2; the kernel remains internal.
 // See ADR-001 for the rationale.
 type TemplateKind string
 
@@ -27,6 +44,16 @@ const (
 	// generalised "two independent records of the same money match" check;
 	// see internal/templates/source.go.
 	TemplateSourceParity TemplateKind = "source_parity"
+	// TemplateBalanceEquation is the V2 N-source equality primitive. It asserts
+	// that an integer-weighted sum of named balances is zero within tolerance.
+	TemplateBalanceEquation TemplateKind = "balance_equation"
+	// TemplateExchangeRateBounds is the V2 cross-asset rate primitive. It checks
+	// the exact quote-major/base-major ratio against inclusive bounds.
+	TemplateExchangeRateBounds TemplateKind = "exchange_rate_bounds"
+	// TemplateSourceConsensus is the V2 symmetric N-source agreement primitive.
+	TemplateSourceConsensus TemplateKind = "source_consensus"
+	// TemplateCoverageRatioBounds compares exact signed multi-source portfolios.
+	TemplateCoverageRatioBounds TemplateKind = "coverage_ratio_bounds"
 )
 
 // Severity is shared between Rule (declared severity at creation) and Alert
@@ -123,17 +150,19 @@ type Schedule struct {
 type Rule struct {
 	bun.BaseModel `bun:"reconciliations.rule" json:"-"`
 
-	ID            uuid.UUID         `bun:",pk,nullzero"           json:"id"`
-	Name          string            `bun:",notnull"               json:"name"`
-	TemplateKind  TemplateKind      `bun:"template_kind,notnull"  json:"templateKind"`
-	TemplateSpec  json.RawMessage   `bun:"template_spec,type:jsonb,notnull" json:"templateSpec"`
-	CompiledCEL   string            `bun:"compiled_cel,notnull"   json:"compiledCEL,omitempty"`
-	Enabled       bool              `bun:",notnull"               json:"enabled"`
-	Severity      Severity          `bun:",notnull"               json:"severity"`
-	Cadence       Cadence           `bun:",notnull"               json:"cadence"`
-	Schedule      *Schedule         `bun:",type:jsonb"            json:"schedule,omitempty"`
-	Notifications []string          `bun:",type:jsonb"            json:"notifications,omitempty"`
-	Labels        map[string]string `bun:",type:jsonb"            json:"labels,omitempty"`
-	CreatedAt     time.Time         `bun:"created_at,notnull,nullzero" json:"createdAt"`
-	UpdatedAt     time.Time         `bun:"updated_at,notnull,nullzero" json:"updatedAt"`
+	ID              uuid.UUID         `bun:",pk,nullzero"           json:"id"`
+	ContractVersion ContractVersion   `bun:"-" json:"-"`
+	Revision        string            `bun:"-" json:"-"`
+	Name            string            `bun:",notnull"               json:"name"`
+	TemplateKind    TemplateKind      `bun:"template_kind,notnull"  json:"templateKind"`
+	TemplateSpec    json.RawMessage   `bun:"template_spec,type:jsonb,notnull" json:"templateSpec"`
+	CompiledCEL     string            `bun:"compiled_cel,notnull"   json:"compiledCEL,omitempty"`
+	Enabled         bool              `bun:",notnull"               json:"enabled"`
+	Severity        Severity          `bun:",notnull"               json:"severity"`
+	Cadence         Cadence           `bun:",notnull"               json:"cadence"`
+	Schedule        *Schedule         `bun:",type:jsonb"            json:"schedule,omitempty"`
+	Notifications   []string          `bun:",type:jsonb"            json:"notifications,omitempty"`
+	Labels          map[string]string `bun:",type:jsonb"            json:"labels,omitempty"`
+	CreatedAt       time.Time         `bun:"created_at,notnull,nullzero" json:"createdAt"`
+	UpdatedAt       time.Time         `bun:"updated_at,notnull,nullzero" json:"updatedAt"`
 }

--- a/internal/store/activity.go
+++ b/internal/store/activity.go
@@ -1,0 +1,7 @@
+package store
+
+import "github.com/formancehq/reconciliation/internal/models"
+
+type RuleActivitiesFilters struct {
+	ContractVersion *models.ContractVersion
+}

--- a/internal/store/alert.go
+++ b/internal/store/alert.go
@@ -12,8 +12,9 @@ import (
 // first open, re-open, and on-going failures — the storage layer figures out
 // what kind of transition is happening based on the current row state.
 type OpenAlertInput struct {
-	RuleID      uuid.UUID
-	Fingerprint string
+	RuleID          uuid.UUID
+	ContractVersion models.ContractVersion
+	Fingerprint     string
 	// PeriodID scopes the alert to a reconciliation period. Empty defaults to
 	// models.ContinuousPeriod, which reproduces the original
 	// (rule_id, fingerprint) dedup. The caller (the evaluation service)

--- a/internal/store/capture.go
+++ b/internal/store/capture.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/formancehq/reconciliation/internal/models"
 	"github.com/google/uuid"
 )
 
@@ -13,12 +14,18 @@ import (
 // evidence for automatic alert resolutions — recorded independently of the
 // alert lifecycle.
 type CaptureInput struct {
-	RuleID       uuid.UUID
-	TemplateKind string
-	PeriodID     string
-	EvaluationID uuid.UUID
-	CapturedAt   time.Time
-	Verdict      string          // "pass" | "fail"
-	Trigger      string          // "scheduled" | "manual"
-	Evidence     json.RawMessage // the evaluation's outcome evidence (bounded)
+	RuleID          uuid.UUID
+	ContractVersion models.ContractVersion
+	TemplateKind    string
+	PeriodID        string
+	EvaluationID    uuid.UUID
+	CapturedAt      time.Time
+	Verdict         string          // "pass" | "fail"
+	Trigger         string          // "scheduled" | "manual"
+	Evidence        json.RawMessage // the evaluation's outcome evidence (bounded)
+	RuleRevision    string
+	PIT             time.Time
+	StartedAt       time.Time
+	Result          models.EvaluationResult
+	Error           string
 }

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -3,6 +3,7 @@ package store
 import (
 	"github.com/formancehq/go-libs/bun/bunpaginate"
 	"github.com/formancehq/go-libs/query"
+	"github.com/formancehq/reconciliation/internal/models"
 )
 
 type PaginatedQueryOptions[T any] struct {
@@ -30,7 +31,9 @@ func NewPaginatedQueryOptions[T any](options T) PaginatedQueryOptions[T] {
 	}
 }
 
-type RulesFilters struct{}
+type RulesFilters struct {
+	ContractVersion *models.ContractVersion
+}
 
 type GetRulesQuery bunpaginate.OffsetPaginatedQuery[PaginatedQueryOptions[RulesFilters]]
 
@@ -42,7 +45,9 @@ func NewGetRulesQuery(opts PaginatedQueryOptions[RulesFilters]) GetRulesQuery {
 	}
 }
 
-type AlertsFilters struct{}
+type AlertsFilters struct {
+	ContractVersion *models.ContractVersion
+}
 
 type GetAlertsQuery bunpaginate.OffsetPaginatedQuery[PaginatedQueryOptions[AlertsFilters]]
 
@@ -69,7 +74,8 @@ func NewGetAlertEventsQuery(opts PaginatedQueryOptions[AlertEventsFilters]) GetA
 // CapturesFilters scopes a rule's capture history. Period is optional: empty
 // lists every period of the rule; set, it scopes to that (rule, period) bucket.
 type CapturesFilters struct {
-	Period string `json:"period"`
+	Period          string                  `json:"period"`
+	ContractVersion *models.ContractVersion `json:"-"`
 }
 
 type GetCapturesQuery bunpaginate.OffsetPaginatedQuery[PaginatedQueryOptions[CapturesFilters]]
@@ -80,4 +86,10 @@ func NewGetCapturesQuery(opts PaginatedQueryOptions[CapturesFilters]) GetCapture
 		Order:    bunpaginate.OrderAsc,
 		Options:  opts,
 	}
+}
+
+type GetRuleActivitiesQuery bunpaginate.OffsetPaginatedQuery[PaginatedQueryOptions[RuleActivitiesFilters]]
+
+func NewGetRuleActivitiesQuery(opts PaginatedQueryOptions[RuleActivitiesFilters]) GetRuleActivitiesQuery {
+	return GetRuleActivitiesQuery{PageSize: opts.PageSize, Order: bunpaginate.OrderAsc, Options: opts}
 }

--- a/internal/templates/balance_equation.go
+++ b/internal/templates/balance_equation.go
@@ -1,0 +1,168 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+	"github.com/formancehq/reconciliation/internal/models"
+)
+
+var nonNegativeIntegerPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+
+// BalanceEquationSpec asserts that a signed, integer-weighted sum of named
+// balances is zero within an absolute tolerance. A+B=C is represented by
+// coefficients +1,+1,-1.
+type BalanceEquationSpec struct {
+	Sources   []V2NamedSource       `json:"sources"`
+	Terms     []BalanceEquationTerm `json:"terms"`
+	Tolerance string                `json:"tolerance"`
+}
+
+type BalanceEquationTerm struct {
+	Source      string `json:"source"`
+	Coefficient int64  `json:"coefficient"`
+}
+
+type BalanceEquation struct{}
+
+func NewBalanceEquation() *BalanceEquation { return &BalanceEquation{} }
+
+func (*BalanceEquation) Kind() models.TemplateKind { return models.TemplateKind("balance_equation") }
+
+func (t *BalanceEquation) Validate(raw json.RawMessage) error {
+	var spec BalanceEquationSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return err
+	}
+	byID, err := validateV2Sources(spec.Sources)
+	if err != nil {
+		return err
+	}
+	if len(spec.Terms) != len(spec.Sources) {
+		return fmt.Errorf("%w: terms must reference every source exactly once", ErrInvalidSpec)
+	}
+	seen := make(map[string]int, len(spec.Terms))
+	for i, term := range spec.Terms {
+		if _, exists := byID[term.Source]; !exists {
+			return fmt.Errorf("%w: unknown Source %q (field: terms[%d].source)", ErrInvalidSpec, term.Source, i)
+		}
+		if previous, exists := seen[term.Source]; exists {
+			return fmt.Errorf("%w: Source %q is referenced more than once (fields: terms[%d].source, terms[%d].source)", ErrInvalidSpec, term.Source, previous, i)
+		}
+		if term.Coefficient == 0 || term.Coefficient == math.MinInt64 {
+			return fmt.Errorf("%w: coefficient must be a non-zero CEL int (field: terms[%d].coefficient)", ErrInvalidSpec, i)
+		}
+		seen[term.Source] = i
+	}
+	asset := spec.Sources[0].Asset
+	for i := 1; i < len(spec.Sources); i++ {
+		if spec.Sources[i].Asset != asset {
+			return fmt.Errorf("%w: balance_equation sources must declare the same asset (field: sources[%d].asset)", ErrInvalidSpec, i)
+		}
+	}
+	if _, err := parseNonNegativeInteger(spec.Tolerance, "tolerance"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (*BalanceEquation) Queries(raw json.RawMessage) ([]SourceSpec, error) {
+	var spec BalanceEquationSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	return v2Queries(spec.Sources), nil
+}
+
+func (t *BalanceEquation) Explain(raw json.RawMessage) (string, error) {
+	var spec BalanceEquationSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return "", err
+	}
+	return buildBalanceEquationExpression(&spec), nil
+}
+
+func (t *BalanceEquation) Evaluate(ctx context.Context, raw json.RawMessage, eng *engine.Engine, resolvers engine.Resolvers, _ engine.EvalInput) ([]Outcome, error) {
+	var spec BalanceEquationSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	if err := requireResolvers(resolvers, "ledger"); err != nil {
+		return nil, err
+	}
+	tolerance, err := parseNonNegativeInteger(spec.Tolerance, "tolerance")
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := resolveV2Sources(ctx, spec.Sources, resolvers, eng.MaxAccountsScanned())
+	if err != nil {
+		return nil, err
+	}
+
+	residual := new(big.Int)
+	sourceEvidence := make([]map[string]any, 0, len(spec.Terms))
+	for _, term := range spec.Terms {
+		value := resolved[term.Source]
+		contribution := new(big.Int).Mul(value.Balance, big.NewInt(term.Coefficient))
+		residual.Add(residual, contribution)
+		evidence := value.evidence()
+		evidence["coefficient"] = term.Coefficient
+		evidence["contribution"] = contribution.String()
+		sourceEvidence = append(sourceEvidence, evidence)
+	}
+	absResidual := new(big.Int).Abs(new(big.Int).Set(residual))
+	expression := buildBalanceEquationExpression(&spec)
+	asset := spec.Sources[0].Asset
+	return []Outcome{{
+		Fingerprint: fingerprintFor("asset", asset),
+		Passed:      absResidual.Cmp(tolerance) <= 0,
+		Evidence: map[string]any{
+			"schemaVersion":    2,
+			"operation":        "balance_equation",
+			"asset":            asset,
+			"sources":          sourceEvidence,
+			"residual":         residual.String(),
+			"absoluteResidual": absResidual.String(),
+			"tolerance":        tolerance.String(),
+			"compiledCEL":      expression,
+		},
+	}}, nil
+}
+
+func parseNonNegativeInteger(value, field string) (*big.Int, error) {
+	if !nonNegativeIntegerPattern.MatchString(value) {
+		return nil, fmt.Errorf("%w: %s must be a non-negative base-10 integer string", ErrInvalidSpec, field)
+	}
+	if len(value) > 78 {
+		return nil, fmt.Errorf("%w: %s must contain at most 78 digits", ErrInvalidSpec, field)
+	}
+	n, ok := new(big.Int).SetString(value, 10)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s is not a valid integer", ErrInvalidSpec, field)
+	}
+	return n, nil
+}
+
+func buildBalanceEquationExpression(spec *BalanceEquationSpec) string {
+	byID := make(map[string]V2NamedSource, len(spec.Sources))
+	for _, source := range spec.Sources {
+		byID[source.ID] = source
+	}
+	balances := make([]string, 0, len(spec.Terms))
+	coefficients := make([]string, 0, len(spec.Terms))
+	for _, term := range spec.Terms {
+		source := byID[term.Source]
+		balances = append(balances, source.exactBalanceCEL())
+		coefficients = append(coefficients, strconv.FormatInt(term.Coefficient, 10))
+	}
+	return fmt.Sprintf("balanceEquation([%s], [%s], %s)",
+		strings.Join(balances, ", "), strings.Join(coefficients, ", "), celString(spec.Tolerance))
+}

--- a/internal/templates/balance_equation_test.go
+++ b/internal/templates/balance_equation_test.go
@@ -1,0 +1,157 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+)
+
+func v2LedgerSource(id, ledger, query, asset string) V2NamedSource {
+	return V2NamedSource{ID: id, Ledger: ledger, Query: json.RawMessage(query), Asset: asset}
+}
+
+func TestBalanceEquation_Validate(t *testing.T) {
+	t.Parallel()
+	tmpl := NewBalanceEquation()
+	valid := BalanceEquationSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("a", "ledger", `{}`, "USD/2"),
+			v2LedgerSource("b", "ledger", `{}`, "USD/2"),
+		},
+		Terms:     []BalanceEquationTerm{{Source: "a", Coefficient: 1}, {Source: "b", Coefficient: -1}},
+		Tolerance: "0",
+	}
+	if err := tmpl.Validate(mustJSON(t, valid)); err != nil {
+		t.Fatalf("valid spec rejected: %v", err)
+	}
+
+	cases := map[string]BalanceEquationSpec{
+		"duplicate source ID": func() BalanceEquationSpec {
+			s := valid
+			s.Sources = append([]V2NamedSource(nil), valid.Sources...)
+			s.Sources[1].ID = "a"
+			return s
+		}(),
+		"invalid source ID": func() BalanceEquationSpec {
+			s := valid
+			s.Sources = append([]V2NamedSource(nil), valid.Sources...)
+			s.Sources[0].ID = "a|bad"
+			return s
+		}(),
+		"different assets": func() BalanceEquationSpec {
+			s := valid
+			s.Sources = append([]V2NamedSource(nil), valid.Sources...)
+			s.Sources[1].Asset = "EUR/2"
+			return s
+		}(),
+		"zero coefficient": func() BalanceEquationSpec {
+			s := valid
+			s.Terms = append([]BalanceEquationTerm(nil), valid.Terms...)
+			s.Terms[0].Coefficient = 0
+			return s
+		}(),
+		"negative tolerance": func() BalanceEquationSpec {
+			s := valid
+			s.Tolerance = "-1"
+			return s
+		}(),
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := tmpl.Validate(mustJSON(t, spec)); !errors.Is(err, ErrInvalidSpec) {
+				t.Fatalf("expected ErrInvalidSpec, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBalanceEquation_ExactBigIntCELMatchesDirect(t *testing.T) {
+	t.Parallel()
+	const qA = `{"$match":{"address":"a"}}`
+	const qB = `{"$match":{"address":"b"}}`
+	const qC = `{"$match":{"address":"c"}}`
+	a, _ := new(big.Int).SetString("1000000000000000000000000000007", 10)
+	b, _ := new(big.Int).SetString("2000000000000000000000000000011", 10)
+	c := new(big.Int).Add(new(big.Int).Set(a), b)
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + qA: {"USD/2": a},
+		"books|" + qB: {"USD/2": b},
+		"books|" + qC: {"USD/2": c},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := BalanceEquationSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("a", "books", qA, "USD/2"),
+			v2LedgerSource("b", "books", qB, "USD/2"),
+			v2LedgerSource("c", "books", qC, "USD/2"),
+		},
+		Terms: []BalanceEquationTerm{
+			{Source: "a", Coefficient: 1},
+			{Source: "b", Coefficient: 1},
+			{Source: "c", Coefficient: -1},
+		},
+		Tolerance: "0",
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewBalanceEquation()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{PIT: time.Now()})
+	if err != nil {
+		t.Fatalf("direct Evaluate: %v", err)
+	}
+	if len(outcomes) != 1 || !outcomes[0].Passed {
+		t.Fatalf("direct verdict = %+v, want pass", outcomes)
+	}
+	if outcomes[0].Evidence["residual"] != "0" {
+		t.Fatalf("residual = %v, want 0", outcomes[0].Evidence["residual"])
+	}
+	if _, found := outcomes[0].Evidence["leftSource"]; found {
+		t.Fatal("V2 evidence must not contain left/right fields")
+	}
+
+	expression, err := tmpl.Explain(raw)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile exact expression: %v\n%s", err, expression)
+	}
+	celOut, err := eng.Evaluate(context.Background(), compiled, engine.EvalInput{PIT: time.Now()})
+	if err != nil {
+		t.Fatalf("CEL Evaluate: %v", err)
+	}
+	if celOut.Passed != outcomes[0].Passed {
+		t.Fatalf("CEL verdict %v != direct verdict %v", celOut.Passed, outcomes[0].Passed)
+	}
+}
+
+func TestBalanceEquation_MissingLedgerAssetIsExplicitZero(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + q: {"USD/2": big.NewInt(0)},
+		"empty|" + q: {},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	raw := mustJSON(t, BalanceEquationSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("a", "books", q, "USD/2"),
+			v2LedgerSource("b", "empty", q, "USD/2"),
+		},
+		Terms:     []BalanceEquationTerm{{Source: "a", Coefficient: 1}, {Source: "b", Coefficient: -1}},
+		Tolerance: "0",
+	})
+	outcomes, err := NewBalanceEquation().Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	sources := outcomes[0].Evidence["sources"].([]map[string]any)
+	if sources[1]["balance"] != "0" || sources[1]["present"] != false {
+		t.Fatalf("missing evidence = %+v", sources[1])
+	}
+}

--- a/internal/templates/coverage_ratio_bounds.go
+++ b/internal/templates/coverage_ratio_bounds.go
@@ -1,0 +1,191 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+	"github.com/formancehq/reconciliation/internal/models"
+)
+
+// CoverageRatioBoundsSpec compares two signed portfolios of the same asset.
+// Every named source belongs to exactly one side of the ratio.
+type CoverageRatioBoundsSpec struct {
+	Sources          []V2NamedSource       `json:"sources"`
+	NumeratorTerms   []BalanceEquationTerm `json:"numeratorTerms"`
+	DenominatorTerms []BalanceEquationTerm `json:"denominatorTerms"`
+	Ratio            RateConstraint        `json:"ratio"`
+}
+
+type CoverageRatioBounds struct{}
+
+func NewCoverageRatioBounds() *CoverageRatioBounds { return &CoverageRatioBounds{} }
+
+func (*CoverageRatioBounds) Kind() models.TemplateKind { return models.TemplateCoverageRatioBounds }
+
+func (t *CoverageRatioBounds) Validate(raw json.RawMessage) error {
+	var spec CoverageRatioBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return err
+	}
+	byID, err := validateV2Sources(spec.Sources)
+	if err != nil {
+		return err
+	}
+	if err := requireSameSourceAsset(spec.Sources, "coverage_ratio_bounds"); err != nil {
+		return err
+	}
+	if len(spec.NumeratorTerms) == 0 {
+		return fmt.Errorf("%w: numeratorTerms must contain at least one entry", ErrInvalidSpec)
+	}
+	if len(spec.DenominatorTerms) == 0 {
+		return fmt.Errorf("%w: denominatorTerms must contain at least one entry", ErrInvalidSpec)
+	}
+	seen := make(map[string]string, len(spec.Sources))
+	if err := validateCoverageTerms(spec.NumeratorTerms, "numeratorTerms", byID, seen); err != nil {
+		return err
+	}
+	if err := validateCoverageTerms(spec.DenominatorTerms, "denominatorTerms", byID, seen); err != nil {
+		return err
+	}
+	if len(seen) != len(spec.Sources) {
+		for _, source := range spec.Sources {
+			if _, ok := seen[source.ID]; !ok {
+				return fmt.Errorf("%w: Source %q is not assigned to a portfolio (field: sources[%d].id)", ErrInvalidSpec, source.ID, byID[source.ID])
+			}
+		}
+	}
+	_, _, err = spec.Ratio.bounds()
+	return err
+}
+
+func validateCoverageTerms(terms []BalanceEquationTerm, field string, byID map[string]int, seen map[string]string) error {
+	for i, term := range terms {
+		path := fmt.Sprintf("%s[%d]", field, i)
+		if _, ok := byID[term.Source]; !ok {
+			return fmt.Errorf("%w: unknown Source %q (field: %s.source)", ErrInvalidSpec, term.Source, path)
+		}
+		if previous, ok := seen[term.Source]; ok {
+			return fmt.Errorf("%w: Source %q is assigned more than once (fields: %s, %s.source)", ErrInvalidSpec, term.Source, previous, path)
+		}
+		if term.Coefficient == 0 || term.Coefficient == math.MinInt64 {
+			return fmt.Errorf("%w: coefficient must be a non-zero CEL int (field: %s.coefficient)", ErrInvalidSpec, path)
+		}
+		seen[term.Source] = path + ".source"
+	}
+	return nil
+}
+
+func (*CoverageRatioBounds) Queries(raw json.RawMessage) ([]SourceSpec, error) {
+	var spec CoverageRatioBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	return v2Queries(spec.Sources), nil
+}
+
+func (t *CoverageRatioBounds) Explain(raw json.RawMessage) (string, error) {
+	var spec CoverageRatioBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return "", err
+	}
+	minimum, maximum, err := spec.Ratio.bounds()
+	if err != nil {
+		return "", err
+	}
+	byID := make(map[string]V2NamedSource, len(spec.Sources))
+	for _, source := range spec.Sources {
+		byID[source.ID] = source
+	}
+	numeratorBalances, numeratorCoefficients := coverageCELTerms(spec.NumeratorTerms, byID)
+	denominatorBalances, denominatorCoefficients := coverageCELTerms(spec.DenominatorTerms, byID)
+	return fmt.Sprintf("coverageRatioWithin([%s], [%s], [%s], [%s], %s, %s)",
+		strings.Join(numeratorBalances, ", "), strings.Join(numeratorCoefficients, ", "),
+		strings.Join(denominatorBalances, ", "), strings.Join(denominatorCoefficients, ", "),
+		celString(ratDecimal(minimum)), celString(ratDecimal(maximum))), nil
+}
+
+func coverageCELTerms(terms []BalanceEquationTerm, byID map[string]V2NamedSource) ([]string, []string) {
+	balances := make([]string, 0, len(terms))
+	coefficients := make([]string, 0, len(terms))
+	for _, term := range terms {
+		balances = append(balances, byID[term.Source].exactBalanceCEL())
+		coefficients = append(coefficients, strconv.FormatInt(term.Coefficient, 10))
+	}
+	return balances, coefficients
+}
+
+func (t *CoverageRatioBounds) Evaluate(ctx context.Context, raw json.RawMessage, eng *engine.Engine, resolvers engine.Resolvers, _ engine.EvalInput) ([]Outcome, error) {
+	var spec CoverageRatioBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	if err := requireResolvers(resolvers, "ledger"); err != nil {
+		return nil, err
+	}
+	minimum, maximum, err := spec.Ratio.bounds()
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := resolveV2Sources(ctx, spec.Sources, resolvers, eng.MaxAccountsScanned())
+	if err != nil {
+		return nil, err
+	}
+	numeratorTotal, numeratorEvidence := coveragePortfolio(spec.NumeratorTerms, resolved)
+	denominatorTotal, denominatorEvidence := coveragePortfolio(spec.DenominatorTerms, resolved)
+	expression, _ := t.Explain(raw)
+	asset := spec.Sources[0].Asset
+	evidence := map[string]any{
+		"schemaVersion": 2,
+		"operation":     "coverage_ratio_bounds",
+		"asset":         asset,
+		"numerator": map[string]any{
+			"sources": numeratorEvidence,
+			"total":   numeratorTotal.String(),
+		},
+		"denominator": map[string]any{
+			"sources": denominatorEvidence,
+			"total":   denominatorTotal.String(),
+		},
+		"effectiveBounds": map[string]any{
+			"min": ratDecimal(minimum),
+			"max": ratDecimal(maximum),
+		},
+		"compiledCEL": expression,
+	}
+	fingerprint := fingerprintFor("asset", asset)
+	if denominatorTotal.Sign() == 0 {
+		evidence["undefinedReason"] = "denominator_total_zero"
+		return []Outcome{{Fingerprint: fingerprint, Passed: false, Evidence: evidence}}, nil
+	}
+	observed := new(big.Rat).SetFrac(numeratorTotal, denominatorTotal)
+	evidence["observedRatio"] = map[string]any{
+		"numerator":   observed.Num().String(),
+		"denominator": observed.Denom().String(),
+	}
+	return []Outcome{{
+		Fingerprint: fingerprint,
+		Passed:      observed.Cmp(minimum) >= 0 && observed.Cmp(maximum) <= 0,
+		Evidence:    evidence,
+	}}, nil
+}
+
+func coveragePortfolio(terms []BalanceEquationTerm, resolved map[string]resolvedV2Source) (*big.Int, []map[string]any) {
+	total := new(big.Int)
+	evidence := make([]map[string]any, 0, len(terms))
+	for _, term := range terms {
+		value := resolved[term.Source]
+		contribution := new(big.Int).Mul(value.Balance, big.NewInt(term.Coefficient))
+		total.Add(total, contribution)
+		sourceEvidence := value.evidence()
+		sourceEvidence["coefficient"] = term.Coefficient
+		sourceEvidence["contribution"] = contribution.String()
+		evidence = append(evidence, sourceEvidence)
+	}
+	return total, evidence
+}

--- a/internal/templates/coverage_ratio_bounds_test.go
+++ b/internal/templates/coverage_ratio_bounds_test.go
@@ -55,7 +55,7 @@ func TestCoverageRatioBounds_Validate(t *testing.T) {
 	}
 }
 
-func TestCoverageRatioBounds_ExactPortfoliosMatchCEL(t *testing.T) {
+func TestCoverageRatioBounds_ExactPortfoliosMatchCELAtFullTolerance(t *testing.T) {
 	t.Parallel()
 	const (
 		qCash = `{"$match":{"address":"cash"}}`
@@ -77,7 +77,7 @@ func TestCoverageRatioBounds_ExactPortfoliosMatchCEL(t *testing.T) {
 		},
 		NumeratorTerms:   []BalanceEquationTerm{{Source: "cash", Coefficient: 1}, {Source: "securities", Coefficient: 1}},
 		DenominatorTerms: []BalanceEquationTerm{{Source: "liabilities", Coefficient: 1}},
-		Ratio:            RateConstraint{Target: "1.25", ToleranceBps: intPtr(0)},
+		Ratio:            RateConstraint{Target: "1.25", ToleranceBps: intPtr(10_000)},
 	}
 	raw := mustJSON(t, spec)
 	tmpl := NewCoverageRatioBounds()

--- a/internal/templates/coverage_ratio_bounds_test.go
+++ b/internal/templates/coverage_ratio_bounds_test.go
@@ -1,0 +1,126 @@
+package templates
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+)
+
+func TestCoverageRatioBounds_Validate(t *testing.T) {
+	t.Parallel()
+	valid := CoverageRatioBoundsSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("cash", "books", `{}`, "USD/2"),
+			v2LedgerSource("securities", "books", `{}`, "USD/2"),
+			v2LedgerSource("liabilities", "books", `{}`, "USD/2"),
+		},
+		NumeratorTerms:   []BalanceEquationTerm{{Source: "cash", Coefficient: 1}, {Source: "securities", Coefficient: 1}},
+		DenominatorTerms: []BalanceEquationTerm{{Source: "liabilities", Coefficient: 1}},
+		Ratio:            RateConstraint{Min: "1", Max: "1.25"},
+	}
+	requireValidSpec(t, NewCoverageRatioBounds(), valid)
+
+	cases := map[string]CoverageRatioBoundsSpec{
+		"source reused": func() CoverageRatioBoundsSpec {
+			s := valid
+			s.DenominatorTerms = []BalanceEquationTerm{{Source: "cash", Coefficient: 1}}
+			return s
+		}(),
+		"source unused": func() CoverageRatioBoundsSpec {
+			s := valid
+			s.NumeratorTerms = []BalanceEquationTerm{{Source: "cash", Coefficient: 1}}
+			return s
+		}(),
+		"empty numerator": func() CoverageRatioBoundsSpec {
+			s := valid
+			s.NumeratorTerms = nil
+			return s
+		}(),
+		"different assets": func() CoverageRatioBoundsSpec {
+			s := valid
+			s.Sources = append([]V2NamedSource(nil), valid.Sources...)
+			s.Sources[1].Asset = "EUR/2"
+			return s
+		}(),
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := NewCoverageRatioBounds().Validate(mustJSON(t, spec)); !errors.Is(err, ErrInvalidSpec) {
+				t.Fatalf("expected ErrInvalidSpec, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCoverageRatioBounds_ExactPortfoliosMatchCEL(t *testing.T) {
+	t.Parallel()
+	const (
+		qCash = `{"$match":{"address":"cash"}}`
+		qSec  = `{"$match":{"address":"securities"}}`
+		qLiab = `{"$match":{"address":"liabilities"}}`
+	)
+	scale, _ := new(big.Int).SetString("1000000000000000000000000", 10)
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + qCash: {"USD/2": new(big.Int).Mul(big.NewInt(60), scale)},
+		"books|" + qSec:  {"USD/2": new(big.Int).Mul(big.NewInt(40), scale)},
+		"books|" + qLiab: {"USD/2": new(big.Int).Mul(big.NewInt(80), scale)},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := CoverageRatioBoundsSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("cash", "books", qCash, "USD/2"),
+			v2LedgerSource("securities", "books", qSec, "USD/2"),
+			v2LedgerSource("liabilities", "books", qLiab, "USD/2"),
+		},
+		NumeratorTerms:   []BalanceEquationTerm{{Source: "cash", Coefficient: 1}, {Source: "securities", Coefficient: 1}},
+		DenominatorTerms: []BalanceEquationTerm{{Source: "liabilities", Coefficient: 1}},
+		Ratio:            RateConstraint{Target: "1.25", ToleranceBps: intPtr(0)},
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewCoverageRatioBounds()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(outcomes) != 1 || !outcomes[0].Passed {
+		t.Fatalf("outcomes = %+v, want pass", outcomes)
+	}
+	evidence := outcomes[0].Evidence
+	ratio := evidence["observedRatio"].(map[string]any)
+	if ratio["numerator"] != "5" || ratio["denominator"] != "4" {
+		t.Fatalf("observedRatio = %+v", ratio)
+	}
+	assertTemplateCELMatches(t, tmpl, raw, eng, outcomes[0].Passed)
+}
+
+func TestCoverageRatioBounds_ZeroDenominatorIsFailure(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"assets|" + q:      {"USD/2": big.NewInt(100)},
+		"liabilities|" + q: {"USD/2": big.NewInt(0)},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := CoverageRatioBoundsSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("assets", "assets", q, "USD/2"),
+			v2LedgerSource("liabilities", "liabilities", q, "USD/2"),
+		},
+		NumeratorTerms:   []BalanceEquationTerm{{Source: "assets", Coefficient: 1}},
+		DenominatorTerms: []BalanceEquationTerm{{Source: "liabilities", Coefficient: 1}},
+		Ratio:            RateConstraint{Min: "1", Max: "2"},
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewCoverageRatioBounds()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes[0].Passed || outcomes[0].Evidence["undefinedReason"] != "denominator_total_zero" {
+		t.Fatalf("outcome = %+v", outcomes[0])
+	}
+	assertTemplateCELMatches(t, tmpl, raw, eng, outcomes[0].Passed)
+}

--- a/internal/templates/exchange_rate_bounds.go
+++ b/internal/templates/exchange_rate_bounds.go
@@ -1,0 +1,218 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+	"github.com/formancehq/reconciliation/internal/models"
+)
+
+var positiveDecimalPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)(\.[0-9]{1,18})?$`)
+
+type ExchangeRateBoundsSpec struct {
+	Sources     []V2NamedSource `json:"sources"`
+	BaseSource  string          `json:"baseSource"`
+	QuoteSource string          `json:"quoteSource"`
+	Rate        RateConstraint  `json:"rate"`
+}
+
+// RateConstraint accepts exactly one shape: explicit inclusive min/max bounds,
+// or a target with a symmetric basis-point tolerance.
+type RateConstraint struct {
+	Target       string `json:"target,omitempty"`
+	ToleranceBps *int   `json:"toleranceBps,omitempty"`
+	Min          string `json:"min,omitempty"`
+	Max          string `json:"max,omitempty"`
+}
+
+type ExchangeRateBounds struct{}
+
+func NewExchangeRateBounds() *ExchangeRateBounds { return &ExchangeRateBounds{} }
+
+func (*ExchangeRateBounds) Kind() models.TemplateKind {
+	return models.TemplateKind("exchange_rate_bounds")
+}
+
+func (t *ExchangeRateBounds) Validate(raw json.RawMessage) error {
+	var spec ExchangeRateBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return err
+	}
+	byID, err := validateV2Sources(spec.Sources)
+	if err != nil {
+		return err
+	}
+	if len(spec.Sources) != 2 {
+		return fmt.Errorf("%w: exchange_rate_bounds requires exactly two sources", ErrInvalidSpec)
+	}
+	if _, ok := byID[spec.BaseSource]; !ok {
+		return fmt.Errorf("%w: unknown base Source %q (field: baseSource)", ErrInvalidSpec, spec.BaseSource)
+	}
+	if _, ok := byID[spec.QuoteSource]; !ok {
+		return fmt.Errorf("%w: unknown quote Source %q (field: quoteSource)", ErrInvalidSpec, spec.QuoteSource)
+	}
+	if spec.BaseSource == spec.QuoteSource {
+		return fmt.Errorf("%w: baseSource and quoteSource must refer to different sources", ErrInvalidSpec)
+	}
+	_, _, err = spec.Rate.bounds()
+	return err
+}
+
+func (*ExchangeRateBounds) Queries(raw json.RawMessage) ([]SourceSpec, error) {
+	var spec ExchangeRateBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	return v2Queries(spec.Sources), nil
+}
+
+func (t *ExchangeRateBounds) Explain(raw json.RawMessage) (string, error) {
+	var spec ExchangeRateBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return "", err
+	}
+	min, max, err := spec.Rate.bounds()
+	if err != nil {
+		return "", err
+	}
+	return buildExchangeRateExpression(&spec, min, max), nil
+}
+
+func (t *ExchangeRateBounds) Evaluate(ctx context.Context, raw json.RawMessage, eng *engine.Engine, resolvers engine.Resolvers, _ engine.EvalInput) ([]Outcome, error) {
+	var spec ExchangeRateBoundsSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	if err := requireResolvers(resolvers, "ledger"); err != nil {
+		return nil, err
+	}
+	minRate, maxRate, err := spec.Rate.bounds()
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := resolveV2Sources(ctx, spec.Sources, resolvers, eng.MaxAccountsScanned())
+	if err != nil {
+		return nil, err
+	}
+	base := resolved[spec.BaseSource]
+	quote := resolved[spec.QuoteSource]
+	expression := buildExchangeRateExpression(&spec, minRate, maxRate)
+	evidence := map[string]any{
+		"schemaVersion": 2,
+		"operation":     "exchange_rate_bounds",
+		"base":          base.evidence(),
+		"quote":         quote.evidence(),
+		"effectiveBounds": map[string]any{
+			"min": ratDecimal(minRate),
+			"max": ratDecimal(maxRate),
+		},
+		"compiledCEL": expression,
+	}
+	fingerprint := fingerprintFor("baseSource", base.Spec.ID, "quoteSource", quote.Spec.ID)
+	if base.Balance.Sign() == 0 {
+		evidence["undefinedReason"] = "base_balance_zero"
+		return []Outcome{{Fingerprint: fingerprint, Passed: false, Evidence: evidence}}, nil
+	}
+
+	observed := observedRate(base, quote)
+	evidence["observedRate"] = map[string]any{
+		"numerator":   observed.Num().String(),
+		"denominator": observed.Denom().String(),
+	}
+	passed := observed.Cmp(minRate) >= 0 && observed.Cmp(maxRate) <= 0
+	return []Outcome{{Fingerprint: fingerprint, Passed: passed, Evidence: evidence}}, nil
+}
+
+func (r RateConstraint) bounds() (*big.Rat, *big.Rat, error) {
+	targetShape := r.Target != "" || r.ToleranceBps != nil
+	boundsShape := r.Min != "" || r.Max != ""
+	if targetShape == boundsShape {
+		return nil, nil, fmt.Errorf("%w: rate must set exactly one of target+toleranceBps or min+max", ErrInvalidSpec)
+	}
+	if targetShape {
+		if r.Target == "" || r.ToleranceBps == nil {
+			return nil, nil, fmt.Errorf("%w: rate.target and rate.toleranceBps are both required", ErrInvalidSpec)
+		}
+		target, err := parsePositiveDecimal(r.Target, "rate.target")
+		if err != nil {
+			return nil, nil, err
+		}
+		if *r.ToleranceBps < 0 || *r.ToleranceBps > 10_000 {
+			return nil, nil, fmt.Errorf("%w: rate.toleranceBps must be between 0 and 10000", ErrInvalidSpec)
+		}
+		minFactor := big.NewRat(int64(10_000-*r.ToleranceBps), 10_000)
+		maxFactor := big.NewRat(int64(10_000+*r.ToleranceBps), 10_000)
+		return new(big.Rat).Mul(target, minFactor), new(big.Rat).Mul(target, maxFactor), nil
+	}
+	if r.Min == "" || r.Max == "" {
+		return nil, nil, fmt.Errorf("%w: rate.min and rate.max are both required", ErrInvalidSpec)
+	}
+	min, err := parsePositiveDecimal(r.Min, "rate.min")
+	if err != nil {
+		return nil, nil, err
+	}
+	max, err := parsePositiveDecimal(r.Max, "rate.max")
+	if err != nil {
+		return nil, nil, err
+	}
+	if min.Cmp(max) > 0 {
+		return nil, nil, fmt.Errorf("%w: rate.min must be less than or equal to rate.max", ErrInvalidSpec)
+	}
+	return min, max, nil
+}
+
+func parsePositiveDecimal(value, field string) (*big.Rat, error) {
+	if len(value) > 78 || !positiveDecimalPattern.MatchString(value) {
+		return nil, fmt.Errorf("%w: %s must be a positive plain decimal string with at most 18 fractional digits", ErrInvalidSpec, field)
+	}
+	valueRat, ok := new(big.Rat).SetString(value)
+	if !ok || valueRat.Sign() <= 0 {
+		return nil, fmt.Errorf("%w: %s must be greater than zero", ErrInvalidSpec, field)
+	}
+	return valueRat, nil
+}
+
+func assetPrecision(asset string) int {
+	if slash := strings.LastIndexByte(asset, '/'); slash >= 0 {
+		precision, _ := strconv.Atoi(asset[slash+1:])
+		return precision
+	}
+	return 0
+}
+
+func observedRate(base, quote resolvedV2Source) *big.Rat {
+	numerator := new(big.Int).Mul(quote.Balance, pow10(assetPrecision(base.Spec.Asset)))
+	denominator := new(big.Int).Mul(base.Balance, pow10(assetPrecision(quote.Spec.Asset)))
+	return new(big.Rat).SetFrac(numerator, denominator)
+}
+
+func pow10(precision int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+}
+
+func ratDecimal(value *big.Rat) string {
+	// All accepted/derived rates have a denominator made only of 2 and 5, so
+	// at most target-scale+4 digits are sufficient for an exact decimal.
+	text := value.FloatString(22)
+	text = strings.TrimRight(text, "0")
+	text = strings.TrimRight(text, ".")
+	return text
+}
+
+func buildExchangeRateExpression(spec *ExchangeRateBoundsSpec, minRate, maxRate *big.Rat) string {
+	byID := make(map[string]V2NamedSource, len(spec.Sources))
+	for _, source := range spec.Sources {
+		byID[source.ID] = source
+	}
+	base := byID[spec.BaseSource]
+	quote := byID[spec.QuoteSource]
+	return fmt.Sprintf("exchangeRateWithin(%s, %s, %s, %s)",
+		base.exactBalanceCEL(), quote.exactBalanceCEL(),
+		celString(ratDecimal(minRate)), celString(ratDecimal(maxRate)))
+}

--- a/internal/templates/exchange_rate_bounds_test.go
+++ b/internal/templates/exchange_rate_bounds_test.go
@@ -137,3 +137,37 @@ func TestExchangeRateBounds_BaseZeroIsUndefinedFailure(t *testing.T) {
 		t.Fatal("CEL verdict = pass, want base-zero failure")
 	}
 }
+
+func TestExchangeRateBounds_BaseZeroStillResolvesInvalidQuote(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{
+		balances: map[string]map[string]*big.Int{"books|" + q: {"EUR/2": big.NewInt(0)}},
+		accounts: map[string][]engine.Account{"bank|" + q: {{Address: "mirror:bank", Metadata: map[string]string{"amount": "invalid"}}}},
+	}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := ExchangeRateBoundsSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("eur", "books", q, "EUR/2"),
+			{ID: "usd", Kind: SourceAccountMetadata, Ledger: "bank", Query: []byte(q), MetadataKey: "amount", Asset: "USD/2"},
+		},
+		BaseSource: "eur", QuoteSource: "usd",
+		Rate: RateConstraint{Min: "1", Max: "2"},
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewExchangeRateBounds()
+	if _, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{}); err == nil {
+		t.Fatal("direct evaluation must reject invalid quote metadata")
+	}
+	expression, err := tmpl.Explain(raw)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if _, err := eng.Evaluate(context.Background(), compiled, engine.EvalInput{}); err == nil {
+		t.Fatal("CEL evaluation must reject invalid quote metadata")
+	}
+}

--- a/internal/templates/exchange_rate_bounds_test.go
+++ b/internal/templates/exchange_rate_bounds_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/formancehq/reconciliation/internal/engine"
@@ -44,7 +45,7 @@ func TestExchangeRateBounds_ValidateRateShapes(t *testing.T) {
 	}
 }
 
-func TestExchangeRateBounds_ExactSignedCELMatchesDirectAtFullTolerance(t *testing.T) {
+func TestExchangeRateBounds_ExactSignedCELMatchesDirectAtFullToleranceAndMaxTarget(t *testing.T) {
 	t.Parallel()
 	const qBase = `{"$match":{"address":"eur"}}`
 	const qQuote = `{"$match":{"address":"usd"}}`
@@ -62,7 +63,7 @@ func TestExchangeRateBounds_ExactSignedCELMatchesDirectAtFullTolerance(t *testin
 			v2LedgerSource("usd", "bank", qQuote, "USD/6"),
 		},
 		BaseSource: "eur", QuoteSource: "usd",
-		Rate: RateConstraint{Target: "1.0800", ToleranceBps: intPtr(10_000)},
+		Rate: RateConstraint{Target: strings.Repeat("9", 78), ToleranceBps: intPtr(10_000)},
 	}
 	raw := mustJSON(t, spec)
 	tmpl := NewExchangeRateBounds()

--- a/internal/templates/exchange_rate_bounds_test.go
+++ b/internal/templates/exchange_rate_bounds_test.go
@@ -1,0 +1,138 @@
+package templates
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+)
+
+func intPtr(v int) *int { return &v }
+
+func TestExchangeRateBounds_ValidateRateShapes(t *testing.T) {
+	t.Parallel()
+	base := []V2NamedSource{
+		v2LedgerSource("eur", "books", `{}`, "EUR/2"),
+		v2LedgerSource("usd", "bank", `{}`, "USD/6"),
+	}
+	valid := []RateConstraint{
+		{Min: "1.0773", Max: "1.0827"},
+		{Target: "1.0800", ToleranceBps: intPtr(25)},
+	}
+	for _, rate := range valid {
+		spec := ExchangeRateBoundsSpec{Sources: base, BaseSource: "eur", QuoteSource: "usd", Rate: rate}
+		if err := NewExchangeRateBounds().Validate(mustJSON(t, spec)); err != nil {
+			t.Errorf("valid rate %+v rejected: %v", rate, err)
+		}
+	}
+	bad := []RateConstraint{
+		{},
+		{Min: "1.1"},
+		{Min: "1.2", Max: "1.1"},
+		{Target: "1.08"},
+		{Target: "1.08", ToleranceBps: intPtr(25), Min: "1", Max: "2"},
+		{Target: "1e3", ToleranceBps: intPtr(25)},
+		{Target: "1.08", ToleranceBps: intPtr(10_001)},
+	}
+	for _, rate := range bad {
+		spec := ExchangeRateBoundsSpec{Sources: base, BaseSource: "eur", QuoteSource: "usd", Rate: rate}
+		if err := NewExchangeRateBounds().Validate(mustJSON(t, spec)); !errors.Is(err, ErrInvalidSpec) {
+			t.Errorf("rate %+v: expected ErrInvalidSpec, got %v", rate, err)
+		}
+	}
+}
+
+func TestExchangeRateBounds_ExactSignedCELMatchesDirect(t *testing.T) {
+	t.Parallel()
+	const qBase = `{"$match":{"address":"eur"}}`
+	const qQuote = `{"$match":{"address":"usd"}}`
+	scale, _ := new(big.Int).SetString("100000000000000000000", 10)
+	base := new(big.Int).Mul(big.NewInt(-10_000), scale)       // -100 EUR
+	quote := new(big.Int).Mul(big.NewInt(-108_000_000), scale) // -108 USD
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + qBase: {"EUR/2": base},
+		"bank|" + qQuote: {"USD/6": quote},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := ExchangeRateBoundsSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("eur", "books", qBase, "EUR/2"),
+			v2LedgerSource("usd", "bank", qQuote, "USD/6"),
+		},
+		BaseSource: "eur", QuoteSource: "usd",
+		Rate: RateConstraint{Target: "1.0800", ToleranceBps: intPtr(25)},
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewExchangeRateBounds()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("direct Evaluate: %v", err)
+	}
+	if len(outcomes) != 1 || !outcomes[0].Passed {
+		t.Fatalf("direct verdict = %+v, want pass", outcomes)
+	}
+	rate := outcomes[0].Evidence["observedRate"].(map[string]any)
+	if rate["numerator"] != "27" || rate["denominator"] != "25" {
+		t.Fatalf("observed rate = %+v, want 27/25", rate)
+	}
+	if _, found := outcomes[0].Evidence["rightBalance"]; found {
+		t.Fatal("V2 evidence must not contain left/right fields")
+	}
+
+	expression, err := tmpl.Explain(raw)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile exact expression: %v\n%s", err, expression)
+	}
+	celOut, err := eng.Evaluate(context.Background(), compiled, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("CEL Evaluate: %v", err)
+	}
+	if celOut.Passed != outcomes[0].Passed {
+		t.Fatalf("CEL verdict %v != direct verdict %v", celOut.Passed, outcomes[0].Passed)
+	}
+}
+
+func TestExchangeRateBounds_BaseZeroIsUndefinedFailure(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + q: {"EUR/2": big.NewInt(0)},
+		"bank|" + q:  {"USD/2": big.NewInt(0)},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := ExchangeRateBoundsSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("eur", "books", q, "EUR/2"),
+			v2LedgerSource("usd", "bank", q, "USD/2"),
+		},
+		BaseSource: "eur", QuoteSource: "usd",
+		Rate: RateConstraint{Min: "1", Max: "2"},
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewExchangeRateBounds()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("direct Evaluate: %v", err)
+	}
+	if outcomes[0].Passed || outcomes[0].Evidence["undefinedReason"] != "base_balance_zero" {
+		t.Fatalf("outcome = %+v, want undefined failure", outcomes[0])
+	}
+	expression, _ := tmpl.Explain(raw)
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	celOut, err := eng.Evaluate(context.Background(), compiled, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("CEL Evaluate: %v", err)
+	}
+	if celOut.Passed {
+		t.Fatal("CEL verdict = pass, want base-zero failure")
+	}
+}

--- a/internal/templates/exchange_rate_bounds_test.go
+++ b/internal/templates/exchange_rate_bounds_test.go
@@ -44,7 +44,7 @@ func TestExchangeRateBounds_ValidateRateShapes(t *testing.T) {
 	}
 }
 
-func TestExchangeRateBounds_ExactSignedCELMatchesDirect(t *testing.T) {
+func TestExchangeRateBounds_ExactSignedCELMatchesDirectAtFullTolerance(t *testing.T) {
 	t.Parallel()
 	const qBase = `{"$match":{"address":"eur"}}`
 	const qQuote = `{"$match":{"address":"usd"}}`
@@ -62,7 +62,7 @@ func TestExchangeRateBounds_ExactSignedCELMatchesDirect(t *testing.T) {
 			v2LedgerSource("usd", "bank", qQuote, "USD/6"),
 		},
 		BaseSource: "eur", QuoteSource: "usd",
-		Rate: RateConstraint{Target: "1.0800", ToleranceBps: intPtr(25)},
+		Rate: RateConstraint{Target: "1.0800", ToleranceBps: intPtr(10_000)},
 	}
 	raw := mustJSON(t, spec)
 	tmpl := NewExchangeRateBounds()

--- a/internal/templates/source.go
+++ b/internal/templates/source.go
@@ -82,27 +82,34 @@ func (s SourceSpec) kind() SourceKind {
 // VALIDATION. `field` prefixes messages so a caller with multiple sources
 // (left/right) can point at the offending one.
 func (s SourceSpec) Validate(field string) error {
+	return s.validateAs(field, field)
+}
+
+// validateAs keeps the stable machine field path separate from the label shown
+// to an operator. V1 can therefore say Source A / Source B while still
+// returning paths such as left.asset, and V2 can use a caller-defined label.
+func (s SourceSpec) validateAs(field, label string) error {
 	if s.Ledger == "" {
-		return fmt.Errorf("%w: %s.ledger is required", ErrInvalidSpec, field)
+		return fmt.Errorf("%w: Source %s is missing a ledger (field: %s.ledger)", ErrInvalidSpec, label, field)
 	}
 	if !hasMeaningfulJSON(s.Query) {
-		return fmt.Errorf("%w: %s.query is required", ErrInvalidSpec, field)
+		return fmt.Errorf("%w: Source %s is missing a query (field: %s.query)", ErrInvalidSpec, label, field)
 	}
 	switch s.kind() {
 	case SourceLedger:
 		// ledger + query suffice.
 	case SourceAccountMetadata:
 		if s.MetadataKey == "" {
-			return fmt.Errorf("%w: %s.metadataKey is required for kind %q", ErrInvalidSpec, field, SourceAccountMetadata)
+			return fmt.Errorf("%w: Source %s is missing metadataKey for kind %q (field: %s.metadataKey)", ErrInvalidSpec, label, SourceAccountMetadata, field)
 		}
 		if s.Asset == "" {
-			return fmt.Errorf("%w: %s.asset is required for kind %q", ErrInvalidSpec, field, SourceAccountMetadata)
+			return fmt.Errorf("%w: Source %s is missing an asset (field: %s.asset)", ErrInvalidSpec, label, field)
 		}
 		if !engine.ValidAssetCode(s.Asset) {
-			return fmt.Errorf("%w: %s.asset %q is not a valid asset code", ErrInvalidSpec, field, s.Asset)
+			return fmt.Errorf("%w: Source %s asset %q is not a valid asset code (field: %s.asset)", ErrInvalidSpec, label, s.Asset, field)
 		}
 	default:
-		return fmt.Errorf("%w: %s.kind %q must be one of %q, %q", ErrInvalidSpec, field, s.Kind, SourceLedger, SourceAccountMetadata)
+		return fmt.Errorf("%w: Source %s kind %q must be one of %q, %q (field: %s.kind)", ErrInvalidSpec, label, s.Kind, SourceLedger, SourceAccountMetadata, field)
 	}
 	return nil
 }

--- a/internal/templates/source_consensus.go
+++ b/internal/templates/source_consensus.go
@@ -1,0 +1,129 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+	"github.com/formancehq/reconciliation/internal/models"
+)
+
+// SourceConsensusSpec checks that independent records of the same asset all
+// exist and agree within one symmetric max-minus-min tolerance.
+type SourceConsensusSpec struct {
+	Sources   []V2NamedSource `json:"sources"`
+	Tolerance string          `json:"tolerance"`
+}
+
+type SourceConsensus struct{}
+
+func NewSourceConsensus() *SourceConsensus { return &SourceConsensus{} }
+
+func (*SourceConsensus) Kind() models.TemplateKind { return models.TemplateSourceConsensus }
+
+func (t *SourceConsensus) Validate(raw json.RawMessage) error {
+	var spec SourceConsensusSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return err
+	}
+	if _, err := validateV2Sources(spec.Sources); err != nil {
+		return err
+	}
+	if err := requireSameSourceAsset(spec.Sources, "source_consensus"); err != nil {
+		return err
+	}
+	_, err := parseNonNegativeInteger(spec.Tolerance, "tolerance")
+	return err
+}
+
+func (*SourceConsensus) Queries(raw json.RawMessage) ([]SourceSpec, error) {
+	var spec SourceConsensusSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	return v2Queries(spec.Sources), nil
+}
+
+func (*SourceConsensus) Explain(raw json.RawMessage) (string, error) {
+	var spec SourceConsensusSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return "", err
+	}
+	balances := make([]string, 0, len(spec.Sources))
+	for _, source := range spec.Sources {
+		balances = append(balances, source.exactBalanceCEL())
+	}
+	return fmt.Sprintf("sourceConsensus([%s], %s)", strings.Join(balances, ", "), celString(spec.Tolerance)), nil
+}
+
+func (t *SourceConsensus) Evaluate(ctx context.Context, raw json.RawMessage, eng *engine.Engine, resolvers engine.Resolvers, _ engine.EvalInput) ([]Outcome, error) {
+	var spec SourceConsensusSpec
+	if err := unmarshalSpec(raw, &spec); err != nil {
+		return nil, err
+	}
+	if err := requireResolvers(resolvers, "ledger"); err != nil {
+		return nil, err
+	}
+	tolerance, err := parseNonNegativeInteger(spec.Tolerance, "tolerance")
+	if err != nil {
+		return nil, err
+	}
+
+	sourceEvidence := make([]map[string]any, 0, len(spec.Sources))
+	missing := make([]string, 0)
+	var minimum, maximum *resolvedV2Source
+	resolvedSources, err := resolveV2Sources(ctx, spec.Sources, resolvers, eng.MaxAccountsScanned())
+	if err != nil {
+		return nil, err
+	}
+	for _, source := range spec.Sources {
+		resolved := resolvedSources[source.ID]
+		sourceEvidence = append(sourceEvidence, resolved.evidence())
+		if !resolved.Present {
+			missing = append(missing, source.ID)
+		}
+		if minimum == nil || resolved.Balance.Cmp(minimum.Balance) < 0 {
+			candidate := resolved
+			minimum = &candidate
+		}
+		if maximum == nil || resolved.Balance.Cmp(maximum.Balance) > 0 {
+			candidate := resolved
+			maximum = &candidate
+		}
+	}
+
+	spread := new(big.Int).Sub(maximum.Balance, minimum.Balance)
+	expression, _ := t.Explain(raw)
+	asset := spec.Sources[0].Asset
+	return []Outcome{{
+		Fingerprint: fingerprintFor("asset", asset),
+		Passed:      len(missing) == 0 && spread.Cmp(tolerance) <= 0,
+		Evidence: map[string]any{
+			"schemaVersion":  2,
+			"operation":      "source_consensus",
+			"asset":          asset,
+			"sources":        sourceEvidence,
+			"minimumSource":  minimum.Spec.ID,
+			"minimumBalance": minimum.Balance.String(),
+			"maximumSource":  maximum.Spec.ID,
+			"maximumBalance": maximum.Balance.String(),
+			"spread":         spread.String(),
+			"tolerance":      tolerance.String(),
+			"missingSources": missing,
+			"compiledCEL":    expression,
+		},
+	}}, nil
+}
+
+func requireSameSourceAsset(sources []V2NamedSource, operation string) error {
+	asset := sources[0].Asset
+	for i := 1; i < len(sources); i++ {
+		if sources[i].Asset != asset {
+			return fmt.Errorf("%w: %s sources must declare the same asset (field: sources[%d].asset)", ErrInvalidSpec, operation, i)
+		}
+	}
+	return nil
+}

--- a/internal/templates/source_consensus_test.go
+++ b/internal/templates/source_consensus_test.go
@@ -1,0 +1,186 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+)
+
+func TestSourceConsensus_Validate(t *testing.T) {
+	t.Parallel()
+	valid := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("book", "books", `{}`, "USD/2"),
+			v2LedgerSource("bank", "bank", `{}`, "USD/2"),
+			v2LedgerSource("processor", "processor", `{}`, "USD/2"),
+		},
+		Tolerance: "10",
+	}
+	requireValidSpec(t, NewSourceConsensus(), valid)
+
+	differentAsset := valid
+	differentAsset.Sources = append([]V2NamedSource(nil), valid.Sources...)
+	differentAsset.Sources[2].Asset = "EUR/2"
+	if err := NewSourceConsensus().Validate(mustJSON(t, differentAsset)); !errors.Is(err, ErrInvalidSpec) {
+		t.Fatalf("different assets: expected ErrInvalidSpec, got %v", err)
+	}
+
+	negativeTolerance := valid
+	negativeTolerance.Tolerance = "-1"
+	if err := NewSourceConsensus().Validate(mustJSON(t, negativeTolerance)); !errors.Is(err, ErrInvalidSpec) {
+		t.Fatalf("negative tolerance: expected ErrInvalidSpec, got %v", err)
+	}
+}
+
+func TestSourceConsensus_ExactSpreadMatchesCEL(t *testing.T) {
+	t.Parallel()
+	const (
+		qA = `{"$match":{"address":"a"}}`
+		qB = `{"$match":{"address":"b"}}`
+		qC = `{"$match":{"address":"c"}}`
+	)
+	base, _ := new(big.Int).SetString("1000000000000000000000000000000", 10)
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + qA: {"USD/2": new(big.Int).Add(new(big.Int).Set(base), big.NewInt(4))},
+		"bank|" + qB:  {"USD/2": new(big.Int).Add(new(big.Int).Set(base), big.NewInt(10))},
+		"proc|" + qC:  {"USD/2": new(big.Int).Add(new(big.Int).Set(base), big.NewInt(7))},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("book", "books", qA, "USD/2"),
+			v2LedgerSource("bank", "bank", qB, "USD/2"),
+			v2LedgerSource("processor", "proc", qC, "USD/2"),
+		},
+		Tolerance: "6",
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewSourceConsensus()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(outcomes) != 1 || !outcomes[0].Passed {
+		t.Fatalf("outcomes = %+v, want pass", outcomes)
+	}
+	evidence := outcomes[0].Evidence
+	if evidence["spread"] != "6" || evidence["minimumSource"] != "book" || evidence["maximumSource"] != "bank" {
+		t.Fatalf("evidence = %+v", evidence)
+	}
+	assertTemplateCELMatches(t, tmpl, raw, eng, outcomes[0].Passed)
+}
+
+func TestSourceConsensus_MissingSourceFails(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{balances: map[string]map[string]*big.Int{
+		"books|" + q: {"USD/2": big.NewInt(0)},
+		"bank|" + q:  {},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			v2LedgerSource("book", "books", q, "USD/2"),
+			v2LedgerSource("bank", "bank", q, "USD/2"),
+		},
+		Tolerance: "0",
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewSourceConsensus()
+	outcomes, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes[0].Passed {
+		t.Fatal("missing source must fail consensus")
+	}
+	missing := outcomes[0].Evidence["missingSources"].([]string)
+	if len(missing) != 1 || missing[0] != "bank" {
+		t.Fatalf("missingSources = %v", missing)
+	}
+	assertTemplateCELMatches(t, tmpl, raw, eng, outcomes[0].Passed)
+}
+
+func TestSourceConsensus_EmptyMetadataQueryIsMissing(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{accounts: map[string][]engine.Account{
+		"book|" + q: {{Address: "mirror:book", Metadata: map[string]string{"amount": "0"}}},
+		"bank|" + q: nil,
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			{ID: "book", Kind: SourceAccountMetadata, Ledger: "book", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+			{ID: "bank", Kind: SourceAccountMetadata, Ledger: "bank", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+		},
+		Tolerance: "0",
+	}
+	outcomes, err := NewSourceConsensus().Evaluate(context.Background(), mustJSON(t, spec), eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes[0].Passed {
+		t.Fatal("an empty metadata query must fail consensus presence")
+	}
+	missing := outcomes[0].Evidence["missingSources"].([]string)
+	if len(missing) != 1 || missing[0] != "bank" {
+		t.Fatalf("missingSources = %v, want [bank]", missing)
+	}
+}
+
+func TestV2MetadataSourcesShareEvaluationAccountBudget(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{accounts: map[string][]engine.Account{
+		"book|" + q: {{Address: "mirror:book", Metadata: map[string]string{"amount": "10"}}},
+		"bank|" + q: {{Address: "mirror:bank", Metadata: map[string]string{"amount": "10"}}},
+	}}
+	resolvers := engine.Resolvers{Ledger: ledger}
+	eng, err := engine.New(resolvers, engine.Limits{MaxAccountsScanned: 1})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	spec := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			{ID: "book", Kind: SourceAccountMetadata, Ledger: "book", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+			{ID: "bank", Kind: SourceAccountMetadata, Ledger: "bank", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+		},
+		Tolerance: "0",
+	}
+	_, err = NewSourceConsensus().Evaluate(context.Background(), mustJSON(t, spec), eng, resolvers, engine.EvalInput{})
+	if err == nil || !strings.Contains(err.Error(), "evaluation budget exceeded") {
+		t.Fatalf("expected cumulative evaluation budget error, got %v", err)
+	}
+}
+
+func requireValidSpec(t *testing.T, evaluator Evaluator, spec any) {
+	t.Helper()
+	if err := evaluator.Validate(mustJSON(t, spec)); err != nil {
+		t.Fatalf("valid spec rejected: %v", err)
+	}
+}
+
+func assertTemplateCELMatches(t *testing.T, evaluator Evaluator, raw []byte, eng *engine.Engine, direct bool) {
+	t.Helper()
+	expression, err := evaluator.Explain(raw)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile %q: %v", expression, err)
+	}
+	result, err := eng.Evaluate(context.Background(), compiled, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate CEL %q: %v", expression, err)
+	}
+	if result.Passed != direct {
+		t.Fatalf("CEL verdict %v != direct verdict %v", result.Passed, direct)
+	}
+}

--- a/internal/templates/source_consensus_test.go
+++ b/internal/templates/source_consensus_test.go
@@ -158,6 +158,18 @@ func TestV2MetadataSourcesShareEvaluationAccountBudget(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "budget") {
 		t.Fatalf("expected cumulative evaluation budget error, got %v", err)
 	}
+	expression, err := NewSourceConsensus().Explain(mustJSON(t, spec))
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	_, err = eng.Evaluate(context.Background(), compiled, engine.EvalInput{})
+	if err == nil || !strings.Contains(err.Error(), "budget") {
+		t.Fatalf("expected cumulative CEL evaluation budget error, got %v", err)
+	}
 }
 
 func TestV2MetadataSourcesAllowZeroMatchAtExhaustedBudget(t *testing.T) {

--- a/internal/templates/source_consensus_test.go
+++ b/internal/templates/source_consensus_test.go
@@ -132,6 +132,7 @@ func TestSourceConsensus_EmptyMetadataQueryIsMissing(t *testing.T) {
 	if len(missing) != 1 || missing[0] != "bank" {
 		t.Fatalf("missingSources = %v, want [bank]", missing)
 	}
+	assertTemplateCELMatches(t, NewSourceConsensus(), mustJSON(t, spec), eng, outcomes[0].Passed)
 }
 
 func TestV2MetadataSourcesShareEvaluationAccountBudget(t *testing.T) {

--- a/internal/templates/source_consensus_test.go
+++ b/internal/templates/source_consensus_test.go
@@ -154,8 +154,41 @@ func TestV2MetadataSourcesShareEvaluationAccountBudget(t *testing.T) {
 		Tolerance: "0",
 	}
 	_, err = NewSourceConsensus().Evaluate(context.Background(), mustJSON(t, spec), eng, resolvers, engine.EvalInput{})
-	if err == nil || !strings.Contains(err.Error(), "evaluation budget exceeded") {
+	if err == nil || !strings.Contains(err.Error(), "budget") {
 		t.Fatalf("expected cumulative evaluation budget error, got %v", err)
+	}
+}
+
+func TestV2MetadataSourcesAllowZeroMatchAtExhaustedBudget(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{accounts: map[string][]engine.Account{
+		"book|" + q: {{Address: "mirror:book", Metadata: map[string]string{"amount": "10"}}},
+		"bank|" + q: nil,
+	}}
+	resolvers := engine.Resolvers{Ledger: ledger}
+	eng, err := engine.New(resolvers, engine.Limits{MaxAccountsScanned: 1})
+	if err != nil {
+		t.Fatalf("engine.New: %v", err)
+	}
+	spec := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			{ID: "book", Kind: SourceAccountMetadata, Ledger: "book", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+			{ID: "bank", Kind: SourceAccountMetadata, Ledger: "bank", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+		},
+		Tolerance: "0",
+	}
+
+	outcomes, err := NewSourceConsensus().Evaluate(context.Background(), mustJSON(t, spec), eng, resolvers, engine.EvalInput{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if outcomes[0].Passed {
+		t.Fatal("zero-match source must fail consensus presence")
+	}
+	missing := outcomes[0].Evidence["missingSources"].([]string)
+	if len(missing) != 1 || missing[0] != "bank" {
+		t.Fatalf("missingSources = %v, want [bank]", missing)
 	}
 }
 

--- a/internal/templates/source_consensus_test.go
+++ b/internal/templates/source_consensus_test.go
@@ -135,6 +135,39 @@ func TestSourceConsensus_EmptyMetadataQueryIsMissing(t *testing.T) {
 	assertTemplateCELMatches(t, NewSourceConsensus(), mustJSON(t, spec), eng, outcomes[0].Passed)
 }
 
+func TestSourceConsensus_MissingSourceStillResolvesLaterInvalidSource(t *testing.T) {
+	t.Parallel()
+	const q = `{}`
+	ledger := &fakeLedger{accounts: map[string][]engine.Account{
+		"book|" + q: nil,
+		"bank|" + q: {{Address: "mirror:bank", Metadata: map[string]string{"amount": "invalid"}}},
+	}}
+	eng, resolvers := newTestEngine(t, ledger)
+	spec := SourceConsensusSpec{
+		Sources: []V2NamedSource{
+			{ID: "book", Kind: SourceAccountMetadata, Ledger: "book", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+			{ID: "bank", Kind: SourceAccountMetadata, Ledger: "bank", Query: json.RawMessage(q), MetadataKey: "amount", Asset: "USD/2"},
+		},
+		Tolerance: "0",
+	}
+	raw := mustJSON(t, spec)
+	tmpl := NewSourceConsensus()
+	if _, err := tmpl.Evaluate(context.Background(), raw, eng, resolvers, engine.EvalInput{}); err == nil {
+		t.Fatal("direct evaluation must reject later invalid metadata")
+	}
+	expression, err := tmpl.Explain(raw)
+	if err != nil {
+		t.Fatalf("Explain: %v", err)
+	}
+	compiled, err := eng.Compile(expression)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if _, err := eng.Evaluate(context.Background(), compiled, engine.EvalInput{}); err == nil {
+		t.Fatal("CEL evaluation must reject later invalid metadata")
+	}
+}
+
 func TestV2MetadataSourcesShareEvaluationAccountBudget(t *testing.T) {
 	t.Parallel()
 	const q = `{}`

--- a/internal/templates/source_parity.go
+++ b/internal/templates/source_parity.go
@@ -46,10 +46,10 @@ func (t *SourceParity) Validate(raw json.RawMessage) error {
 	if err := unmarshalSpec(raw, &spec); err != nil {
 		return err
 	}
-	if err := spec.Left.Validate("left"); err != nil {
+	if err := spec.Left.validateAs("left", "A"); err != nil {
 		return err
 	}
-	if err := spec.Right.Validate("right"); err != nil {
+	if err := spec.Right.validateAs("right", "B"); err != nil {
 		return err
 	}
 	if !spec.Scope.Valid() {
@@ -65,7 +65,7 @@ func (t *SourceParity) Validate(raw json.RawMessage) error {
 	if spec.Left.kind() == SourceAccountMetadata &&
 		spec.Right.kind() == SourceAccountMetadata &&
 		spec.Left.Asset != spec.Right.Asset {
-		return fmt.Errorf("%w: account_metadata sources must declare the same asset (left %q, right %q)", ErrInvalidSpec, spec.Left.Asset, spec.Right.Asset)
+		return fmt.Errorf("%w: Source A and Source B must declare the same asset for account_metadata (fields: left.asset, right.asset; values: %q, %q)", ErrInvalidSpec, spec.Left.Asset, spec.Right.Asset)
 	}
 	for asset, tol := range spec.Tolerance {
 		if tol < 0 {

--- a/internal/templates/source_parity_test.go
+++ b/internal/templates/source_parity_test.go
@@ -34,6 +34,26 @@ func TestSourceParity_Validate(t *testing.T) {
 	}
 }
 
+func TestSourceParity_ValidationUsesHumanLabelsAndMachinePaths(t *testing.T) {
+	tmpl := NewSourceParity()
+
+	err := tmpl.Validate(mustJSON(t, ParitySpec{
+		Left:  SourceSpec{Query: json.RawMessage(`{}`)},
+		Right: ledgerSource("control", `{}`),
+	}))
+	if err == nil || !strings.Contains(err.Error(), "Source A") || !strings.Contains(err.Error(), "field: left.ledger") {
+		t.Fatalf("left validation error = %v, want Source A and left.ledger", err)
+	}
+
+	err = tmpl.Validate(mustJSON(t, ParitySpec{
+		Left:  ledgerSource("book", `{}`),
+		Right: SourceSpec{Ledger: "control"},
+	}))
+	if err == nil || !strings.Contains(err.Error(), "Source B") || !strings.Contains(err.Error(), "field: right.query") {
+		t.Fatalf("right validation error = %v, want Source B and right.query", err)
+	}
+}
+
 // TestSourceParity_Drift — the drift use case expressed as parity: two ledgers'
 // records of the same money should be equal within tolerance.
 func TestSourceParity_Drift(t *testing.T) {

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -1,10 +1,10 @@
-// Package templates is the V1 GA public-API surface for rules. Each Evaluator
+// Package templates is the versioned public-API surface for rules. Each Evaluator
 // owns a typed spec, a validator, a representative compiler (for the
 // rule.compiled_cel explainability field), and an end-to-end evaluation flow
 // that produces one Outcome per fingerprint axis (typically per-asset).
 //
-// Templates are the entire customer-facing surface at V1 GA — raw CEL is
-// internal-only; see ADR-001 and the project memory `reconciliation-v1-scope-discipline`.
+// V1 and V2 templates share this registry and are isolated at the HTTP and
+// persistence contract seams. Raw CEL remains internal-only; see ADR-001.
 package templates
 
 import (
@@ -93,12 +93,16 @@ func NewRegistry(evaluators ...Evaluator) *Registry {
 	return r
 }
 
-// DefaultRegistry returns a Registry with all V1 GA templates registered.
+// DefaultRegistry returns a Registry with all shipped V1 and V2 templates.
 func DefaultRegistry() *Registry {
 	return NewRegistry(
 		NewLedgerInvariant(),
 		NewAccountThreshold(),
 		NewSourceParity(),
+		NewBalanceEquation(),
+		NewExchangeRateBounds(),
+		NewSourceConsensus(),
+		NewCoverageRatioBounds(),
 	)
 }
 

--- a/internal/templates/v2_source.go
+++ b/internal/templates/v2_source.go
@@ -114,9 +114,6 @@ func resolveV2Sources(ctx context.Context, sources []V2NamedSource, resolvers en
 func resolveV2Source(ctx context.Context, source V2NamedSource, resolvers engine.Resolvers, limit int) (resolvedV2Source, int, error) {
 	spec := source.sourceSpec()
 	if spec.kind() == SourceAccountMetadata {
-		if limit <= 0 {
-			return resolvedV2Source{}, 0, fmt.Errorf("resolve Source %q: evaluation budget exceeded: scanned at least %d accounts (limit %d)", source.displayLabel(), limit+1, limit)
-		}
 		accounts, err := resolvers.Ledger.ListAccounts(ctx, spec.Ledger, spec.Query, limit)
 		if err != nil {
 			return resolvedV2Source{}, 0, fmt.Errorf("resolve Source %q: %w", source.displayLabel(), err)

--- a/internal/templates/v2_source.go
+++ b/internal/templates/v2_source.go
@@ -1,0 +1,163 @@
+package templates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"regexp"
+
+	"github.com/formancehq/reconciliation/internal/engine"
+)
+
+const maxV2Sources = 32
+
+var v2SourceIDPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]{0,63}$`)
+
+// V2NamedSource is the common scalar balance input for V2 templates. Unlike
+// the V1 left/right source shape, every source has a stable caller-defined ID
+// and selects exactly one asset.
+type V2NamedSource struct {
+	ID          string          `json:"id"`
+	Label       string          `json:"label,omitempty"`
+	Kind        SourceKind      `json:"kind,omitempty"`
+	Ledger      string          `json:"ledger"`
+	Query       json.RawMessage `json:"query"`
+	MetadataKey string          `json:"metadataKey,omitempty"`
+	Asset       string          `json:"asset"`
+}
+
+func (s V2NamedSource) sourceSpec() SourceSpec {
+	return SourceSpec{
+		Kind:        s.Kind,
+		Ledger:      s.Ledger,
+		Query:       s.Query,
+		MetadataKey: s.MetadataKey,
+		Asset:       s.Asset,
+	}
+}
+
+func (s V2NamedSource) effectiveKind() SourceKind { return s.sourceSpec().kind() }
+
+func (s V2NamedSource) exactBalanceCEL() string {
+	return fmt.Sprintf("exactBalance(ledgerSet(%s, %s), %s, %s)",
+		celString(s.Ledger), celJSON(s.Query), celString(s.Asset), celString(s.MetadataKey))
+}
+
+func (s V2NamedSource) displayLabel() string {
+	if s.Label != "" {
+		return s.Label
+	}
+	return s.ID
+}
+
+func (s V2NamedSource) validate(index int) error {
+	path := fmt.Sprintf("sources[%d]", index)
+	if !v2SourceIDPattern.MatchString(s.ID) {
+		return fmt.Errorf("%w: Source %q has an invalid ID (field: %s.id)", ErrInvalidSpec, s.displayLabel(), path)
+	}
+	if s.Asset == "" {
+		return fmt.Errorf("%w: Source %q is missing an asset (field: %s.asset)", ErrInvalidSpec, s.displayLabel(), path)
+	}
+	if !engine.ValidAssetCode(s.Asset) {
+		return fmt.Errorf("%w: Source %q asset %q is not a valid asset code (field: %s.asset)", ErrInvalidSpec, s.displayLabel(), s.Asset, path)
+	}
+	if s.effectiveKind() == SourceLedger && s.MetadataKey != "" {
+		return fmt.Errorf("%w: Source %q must not set metadataKey for kind %q (field: %s.metadataKey)", ErrInvalidSpec, s.displayLabel(), SourceLedger, path)
+	}
+	if err := s.sourceSpec().validateAs(path, fmt.Sprintf("%q", s.displayLabel())); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateV2Sources(sources []V2NamedSource) (map[string]int, error) {
+	if len(sources) < 2 {
+		return nil, fmt.Errorf("%w: sources must contain at least two entries", ErrInvalidSpec)
+	}
+	if len(sources) > maxV2Sources {
+		return nil, fmt.Errorf("%w: sources must contain at most %d entries", ErrInvalidSpec, maxV2Sources)
+	}
+	byID := make(map[string]int, len(sources))
+	for i, source := range sources {
+		if err := source.validate(i); err != nil {
+			return nil, err
+		}
+		if previous, exists := byID[source.ID]; exists {
+			return nil, fmt.Errorf("%w: Source ID %q is duplicated (fields: sources[%d].id, sources[%d].id)", ErrInvalidSpec, source.ID, previous, i)
+		}
+		byID[source.ID] = i
+	}
+	return byID, nil
+}
+
+type resolvedV2Source struct {
+	Spec    V2NamedSource
+	Balance *big.Int
+	Present bool
+}
+
+func resolveV2Sources(ctx context.Context, sources []V2NamedSource, resolvers engine.Resolvers, maxAccounts int) (map[string]resolvedV2Source, error) {
+	resolved := make(map[string]resolvedV2Source, len(sources))
+	remaining := maxAccounts
+	for _, source := range sources {
+		value, scanned, err := resolveV2Source(ctx, source, resolvers, remaining)
+		if err != nil {
+			return nil, err
+		}
+		remaining -= scanned
+		resolved[source.ID] = value
+	}
+	return resolved, nil
+}
+
+func resolveV2Source(ctx context.Context, source V2NamedSource, resolvers engine.Resolvers, limit int) (resolvedV2Source, int, error) {
+	spec := source.sourceSpec()
+	if spec.kind() == SourceAccountMetadata {
+		if limit <= 0 {
+			return resolvedV2Source{}, 0, fmt.Errorf("resolve Source %q: evaluation budget exceeded: scanned at least %d accounts (limit %d)", source.displayLabel(), limit+1, limit)
+		}
+		accounts, err := resolvers.Ledger.ListAccounts(ctx, spec.Ledger, spec.Query, limit)
+		if err != nil {
+			return resolvedV2Source{}, 0, fmt.Errorf("resolve Source %q: %w", source.displayLabel(), err)
+		}
+		total, err := engine.SumAccountMetadataInt(accounts, spec.MetadataKey)
+		if err != nil {
+			return resolvedV2Source{}, 0, fmt.Errorf("resolve Source %q: %w", source.displayLabel(), err)
+		}
+		return resolvedV2Source{Spec: source, Balance: total, Present: len(accounts) > 0}, len(accounts), nil
+	}
+
+	balances, err := spec.resolve(ctx, resolvers, limit)
+	if err != nil {
+		return resolvedV2Source{}, 0, fmt.Errorf("resolve Source %q: %w", source.displayLabel(), err)
+	}
+	value, present := balances[source.Asset]
+	return resolvedV2Source{
+		Spec:    source,
+		Balance: new(big.Int).Set(zeroIfNil(value)),
+		Present: present,
+	}, 0, nil
+}
+
+func (r resolvedV2Source) evidence() map[string]any {
+	out := map[string]any{
+		"id":      r.Spec.ID,
+		"kind":    string(r.Spec.effectiveKind()),
+		"asset":   r.Spec.Asset,
+		"balance": r.Balance.String(),
+		"present": r.Present,
+	}
+	if r.Spec.Label != "" {
+		out["label"] = r.Spec.Label
+	}
+	return out
+}
+
+func v2Queries(sources []V2NamedSource) []SourceSpec {
+	out := make([]SourceSpec, 0, len(sources))
+	for _, source := range sources {
+		out = append(out, source.sourceSpec())
+	}
+	return out
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -67,7 +67,7 @@ paths:
       security:
         - Authorization: [reconciliation:write]
     delete:
-      summary: Delete a rule (cascades to evaluations + alerts + alert events)
+      summary: Delete a rule definition while preserving its audit history
       operationId: deleteRule
       tags: [reconciliation.v1]
       responses:
@@ -117,6 +117,26 @@ paths:
           schema: { type: string }
       responses:
         '200': { $ref: '#/components/responses/Captures' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+
+  /rules/{ruleID}/timeline:
+    parameters: [{ $ref: '#/components/parameters/RuleID' }]
+    get:
+      summary: List the combined lifecycle and observation history for a rule
+      description: |
+        Returns immutable rule lifecycle, evaluation, and alert lifecycle events
+        in newest-first order. Events are committed to the rule activity stream
+        atomically with the state mutation they describe. History created before
+        the activity-journal rollout may be incomplete.
+      operationId: listRuleTimeline
+      tags: [reconciliation.v1]
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Cursor'
+      responses:
+        '200': { $ref: '#/components/responses/RuleActivities' }
         default: { $ref: '#/components/responses/ErrorResponse' }
       security:
         - Authorization: [reconciliation:read]
@@ -267,6 +287,233 @@ paths:
       security:
         - Authorization: [reconciliation:write]
 
+  /v2/rules:
+    post:
+      summary: Create a V2 multi-source rule
+      operationId: createRuleV2
+      tags: [reconciliation.v2]
+      requestBody: { $ref: '#/components/requestBodies/RuleV2' }
+      responses:
+        '201': { $ref: '#/components/responses/RuleV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+    get:
+      summary: List V2 rules
+      operationId: listRulesV2
+      tags: [reconciliation.v2]
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Cursor'
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/QueryBuilderV2' }
+      responses:
+        '200': { $ref: '#/components/responses/RulesV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+
+  /v2/rules/{ruleID}:
+    parameters: [{ $ref: '#/components/parameters/RuleID' }]
+    get:
+      summary: Get a V2 rule
+      operationId: getRuleV2
+      tags: [reconciliation.v2]
+      responses:
+        '200': { $ref: '#/components/responses/RuleV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+    patch:
+      summary: Patch a V2 rule
+      description: Changing a V2 operation requires both `templateKind` and its matching typed `templateSpec`.
+      operationId: patchRuleV2
+      tags: [reconciliation.v2]
+      requestBody: { $ref: '#/components/requestBodies/RulePatchV2' }
+      responses:
+        '200': { $ref: '#/components/responses/RuleV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+    delete:
+      summary: Delete a V2 rule definition while preserving its audit history
+      operationId: deleteRuleV2
+      tags: [reconciliation.v2]
+      responses:
+        '204': { $ref: '#/components/responses/NoContent' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
+  /v2/rules/{ruleID}/evaluate:
+    post:
+      summary: Evaluate a V2 rule now
+      operationId: evaluateRuleV2
+      tags: [reconciliation.v2]
+      parameters: [{ $ref: '#/components/parameters/RuleID' }]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EvaluateRuleRequestV2' }
+      responses:
+        '200': { $ref: '#/components/responses/EvaluationV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
+  /v2/rules/{ruleID}/captures:
+    parameters: [{ $ref: '#/components/parameters/RuleID' }]
+    get:
+      summary: List a V2 rule's immutable evaluation captures
+      operationId: listRuleCapturesV2
+      tags: [reconciliation.v2]
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Cursor'
+        - name: period
+          in: query
+          required: false
+          description: Scope the history to a single reconciliation period (for example, "2026-03" or "continuous").
+          schema: { type: string }
+      responses:
+        '200': { $ref: '#/components/responses/CapturesV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+
+  /v2/rules/{ruleID}/timeline:
+    parameters: [{ $ref: '#/components/parameters/RuleID' }]
+    get:
+      summary: List the combined lifecycle and observation history for a V2 rule
+      operationId: listRuleTimelineV2
+      tags: [reconciliation.v2]
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Cursor'
+      responses:
+        '200': { $ref: '#/components/responses/RuleActivities' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+
+  /v2/alerts:
+    get:
+      summary: List V2 alerts
+      operationId: listAlertsV2
+      tags: [reconciliation.v2]
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Cursor'
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/QueryBuilderV2' }
+      responses:
+        '200': { $ref: '#/components/responses/AlertsV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+
+  /v2/alerts/{alertID}:
+    parameters: [{ $ref: '#/components/parameters/AlertID' }]
+    get:
+      summary: Get a V2 alert
+      operationId: getAlertV2
+      tags: [reconciliation.v2]
+      responses:
+        '200': { $ref: '#/components/responses/AlertV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:read]
+
+  /v2/alerts/{alertID}/ack:
+    post:
+      summary: Acknowledge a V2 alert
+      operationId: ackAlertV2
+      tags: [reconciliation.v2]
+      parameters: [{ $ref: '#/components/parameters/AlertID' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AckAlertRequestV2' }
+      responses:
+        '200': { $ref: '#/components/responses/AlertV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
+  /v2/alerts/{alertID}/resolve:
+    post:
+      summary: Resolve a V2 alert (fixed_by_booking)
+      operationId: resolveAlertV2
+      tags: [reconciliation.v2]
+      parameters: [{ $ref: '#/components/parameters/AlertID' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ResolveAlertRequestV2' }
+      responses:
+        '200': { $ref: '#/components/responses/AlertV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
+  /v2/alerts/{alertID}/accept:
+    post:
+      summary: Accept a V2 alert (accepted_by_business)
+      operationId: acceptAlertV2
+      tags: [reconciliation.v2]
+      parameters: [{ $ref: '#/components/parameters/AlertID' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AcceptAlertRequestV2' }
+      responses:
+        '200': { $ref: '#/components/responses/AlertV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
+  /v2/alerts/{alertID}/snooze:
+    post:
+      summary: Snooze a V2 alert's notifications until a future instant
+      operationId: snoozeAlertV2
+      tags: [reconciliation.v2]
+      parameters: [{ $ref: '#/components/parameters/AlertID' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SnoozeAlertRequestV2' }
+      responses:
+        '200': { $ref: '#/components/responses/AlertV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
+  /v2/alerts/{alertID}/unsnooze:
+    post:
+      summary: Lift a V2 alert snooze early
+      operationId: unsnoozeAlertV2
+      tags: [reconciliation.v2]
+      parameters: [{ $ref: '#/components/parameters/AlertID' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UnsnoozeAlertRequestV2' }
+      responses:
+        '200': { $ref: '#/components/responses/AlertV2' }
+        default: { $ref: '#/components/responses/ErrorResponse' }
+      security:
+        - Authorization: [reconciliation:write]
+
 components:
   parameters:
     PageSize:
@@ -353,6 +600,41 @@ components:
       content:
         application/json:
           schema: { $ref: '#/components/schemas/CapturesCursorResponse' }
+    RuleActivities:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/RuleActivitiesCursorResponse' }
+    RuleV2:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/RuleResponseV2' }
+    RulesV2:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/RulesCursorResponseV2' }
+    EvaluationV2:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/EvaluationResponseV2' }
+    AlertV2:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/AlertResponseV2' }
+    AlertsV2:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/AlertsCursorResponseV2' }
+    CapturesV2:
+      description: OK
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/CapturesCursorResponseV2' }
   requestBodies:
     Rule:
       required: true
@@ -364,6 +646,16 @@ components:
       content:
         application/json:
           schema: { $ref: '#/components/schemas/RulePatchRequest' }
+    RuleV2:
+      required: true
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/RuleRequestV2' }
+    RulePatchV2:
+      required: true
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/RulePatchRequestV2' }
   schemas:
     QueryBuilder:
       type: object
@@ -677,7 +969,7 @@ components:
         trigger: { type: string, enum: [scheduled, manual] }
         capturedAt: { type: string, format: date-time }
         evidence:
-          description: The evaluation's outcome evidence (present on a fail; bounded).
+          description: The evaluation's outcome evidence.
           type: object
           additionalProperties: true
     CapturesCursorResponse:
@@ -695,6 +987,41 @@ components:
             data:
               type: array
               items: { $ref: '#/components/schemas/Capture' }
+
+    RuleActivity:
+      type: object
+      required: [id, sequence, kind, category, ruleID, contractVersion, occurredAt, recordedAt]
+      properties:
+        id: { type: string, example: "8941:0" }
+        sequence: { type: string, description: Ledger-local ordering key represented as a string for JavaScript safety. }
+        kind:
+          type: string
+          enum: [rule.created, rule.updated, rule.deleted, evaluation.completed, alert.opened, alert.occurred, alert.reopened, alert.acknowledged, alert.resolved, alert.accepted, alert.auto_resolved, alert.snoozed, alert.unsnoozed]
+        category: { type: string, enum: [rule, evaluation, alert] }
+        ruleID: { type: string, format: uuid }
+        contractVersion: { type: integer, enum: [1, 2] }
+        ruleRevision: { type: string }
+        correlationID: { type: string, description: Evaluation ID for evaluation-driven activity. }
+        occurredAt: { type: string, format: date-time }
+        recordedAt: { type: string, format: date-time }
+        payload:
+          type: object
+          additionalProperties: true
+    RuleActivitiesCursorResponse:
+      type: object
+      required: [cursor]
+      properties:
+        cursor:
+          type: object
+          required: [pageSize, hasMore, data]
+          properties:
+            pageSize: { type: integer, format: int64 }
+            hasMore: { type: boolean }
+            previous: { type: string }
+            next: { type: string }
+            data:
+              type: array
+              items: { $ref: '#/components/schemas/RuleActivity' }
 
     AckAlertRequest:
       type: object
@@ -731,6 +1058,675 @@ components:
         until: { type: string, format: date-time }
         note: { type: string }
     UnsnoozeAlertRequest:
+      type: object
+      required: [by]
+      properties:
+        by: { type: string, example: "ops@buildr.com" }
+
+    # --- V2 named multi-source schemas ------------------------------------
+
+    QueryBuilderV2:
+      type: object
+      additionalProperties: true
+    ContractVersionV2:
+      type: integer
+      format: int32
+      enum: [2]
+      readOnly: true
+    TemplateKindV2:
+      type: string
+      enum: [balance_equation, exchange_rate_bounds, source_consensus, coverage_ratio_bounds]
+    SeverityV2:
+      type: string
+      enum: [info, low, medium, high, critical]
+    CadenceV2:
+      type: string
+      enum: [continuous, daily, weekly, monthly]
+      default: continuous
+    ScheduleV2:
+      type: object
+      required: [kind]
+      properties:
+        kind: { type: string, enum: [on_demand, cron] }
+        expr: { type: string, example: "*/15 * * * *" }
+        tz: { type: string, example: "UTC" }
+
+    UnsignedIntegerStringV2:
+      type: string
+      pattern: '^(0|[1-9][0-9]*)$'
+      description: A non-negative base-10 integer encoded as a string to avoid JSON precision loss.
+      example: "1250"
+    SignedIntegerStringV2:
+      type: string
+      pattern: '^-?(0|[1-9][0-9]*)$'
+      description: A signed base-10 integer encoded as a string to avoid JSON precision loss.
+      example: "-1250"
+    PositiveDecimalStringV2:
+      type: string
+      pattern: '^(0|[1-9][0-9]*)(\.[0-9]{1,18})?$'
+      description: A positive plain-decimal value with at most 18 fractional digits; signs and exponent notation are rejected.
+      example: "1.10"
+    AssetV2:
+      type: string
+      minLength: 1
+      description: Ledger asset code including precision, for example `USD/2`.
+      example: USD/2
+    SourceIDV2:
+      type: string
+      pattern: '^[A-Za-z][A-Za-z0-9_-]{0,63}$'
+      description: Stable machine identifier used by terms, fingerprints, and evidence.
+      example: customerBook
+
+    LedgerNamedSourceV2:
+      type: object
+      required: [id, ledger, query, asset]
+      properties:
+        id: { $ref: '#/components/schemas/SourceIDV2' }
+        label: { type: string }
+        kind:
+          type: string
+          enum: [ledger]
+          default: ledger
+        ledger: { type: string, minLength: 1 }
+        query:
+          type: object
+          additionalProperties: true
+        asset: { $ref: '#/components/schemas/AssetV2' }
+    AccountMetadataNamedSourceV2:
+      type: object
+      required: [id, kind, ledger, query, metadataKey, asset]
+      properties:
+        id: { $ref: '#/components/schemas/SourceIDV2' }
+        label: { type: string }
+        kind: { type: string, enum: [account_metadata] }
+        ledger: { type: string, minLength: 1 }
+        query:
+          type: object
+          additionalProperties: true
+        metadataKey:
+          type: string
+          minLength: 1
+          description: Opaque metadata key; the asset is declared independently.
+        asset: { $ref: '#/components/schemas/AssetV2' }
+    NamedSourceV2:
+      oneOf:
+        - $ref: '#/components/schemas/LedgerNamedSourceV2'
+        - $ref: '#/components/schemas/AccountMetadataNamedSourceV2'
+      discriminator:
+        propertyName: kind
+        mapping:
+          ledger: '#/components/schemas/LedgerNamedSourceV2'
+          account_metadata: '#/components/schemas/AccountMetadataNamedSourceV2'
+
+    BalanceEquationTermV2:
+      type: object
+      required: [source, coefficient]
+      properties:
+        source: { $ref: '#/components/schemas/SourceIDV2' }
+        coefficient:
+          description: Non-zero signed integer coefficient for this source.
+          oneOf:
+            - { type: integer, format: int64, maximum: -1 }
+            - { type: integer, format: int64, minimum: 1 }
+    BalanceEquationSpecV2:
+      type: object
+      description: Checks `abs(sum(coefficient * balance)) <= tolerance` for sources declaring the same asset.
+      required: [sources, terms, tolerance]
+      properties:
+        sources:
+          type: array
+          minItems: 2
+          maxItems: 32
+          items: { $ref: '#/components/schemas/NamedSourceV2' }
+          description: Ordered sources with unique IDs. Every source must declare the same asset.
+        terms:
+          type: array
+          minItems: 2
+          maxItems: 32
+          items: { $ref: '#/components/schemas/BalanceEquationTermV2' }
+          description: Each source ID must be referenced exactly once.
+        tolerance: { $ref: '#/components/schemas/UnsignedIntegerStringV2' }
+    ExplicitRateBoundsV2:
+      type: object
+      required: [min, max]
+      properties:
+        min: { $ref: '#/components/schemas/PositiveDecimalStringV2' }
+        max: { $ref: '#/components/schemas/PositiveDecimalStringV2' }
+      description: Inclusive positive lower and upper exchange-rate bounds; min must not exceed max.
+    TargetRateBoundsV2:
+      type: object
+      required: [target, toleranceBps]
+      properties:
+        target: { $ref: '#/components/schemas/PositiveDecimalStringV2' }
+        toleranceBps:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 10000
+      description: Inclusive bounds derived exactly from target plus or minus the basis-point tolerance.
+    ExchangeRateV2:
+      oneOf:
+        - $ref: '#/components/schemas/ExplicitRateBoundsV2'
+        - $ref: '#/components/schemas/TargetRateBoundsV2'
+    ExchangeRateBoundsSpecV2:
+      type: object
+      description: Checks the exact signed quote-major-units per base-major-unit rate using integer cross-multiplication.
+      required: [sources, baseSource, quoteSource, rate]
+      properties:
+        sources:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items: { $ref: '#/components/schemas/NamedSourceV2' }
+          description: Exactly two ordered sources with unique IDs.
+        baseSource: { $ref: '#/components/schemas/SourceIDV2' }
+        quoteSource: { $ref: '#/components/schemas/SourceIDV2' }
+        rate: { $ref: '#/components/schemas/ExchangeRateV2' }
+    SourceConsensusSpecV2:
+      type: object
+      description: Checks that every source is present and `max(balance) - min(balance) <= tolerance` for one shared asset.
+      required: [sources, tolerance]
+      properties:
+        sources:
+          type: array
+          minItems: 2
+          maxItems: 32
+          items: { $ref: '#/components/schemas/NamedSourceV2' }
+          description: Ordered independent records with unique IDs. Every source must declare the same asset.
+        tolerance: { $ref: '#/components/schemas/UnsignedIntegerStringV2' }
+    CoverageRatioBoundsSpecV2:
+      type: object
+      description: Checks the exact ratio of two signed, same-asset portfolios against inclusive bounds.
+      required: [sources, numeratorTerms, denominatorTerms, ratio]
+      properties:
+        sources:
+          type: array
+          minItems: 2
+          maxItems: 32
+          items: { $ref: '#/components/schemas/NamedSourceV2' }
+          description: Every source must declare the same asset and be assigned exactly once across the two portfolios.
+        numeratorTerms:
+          type: array
+          minItems: 1
+          maxItems: 31
+          items: { $ref: '#/components/schemas/BalanceEquationTermV2' }
+        denominatorTerms:
+          type: array
+          minItems: 1
+          maxItems: 31
+          items: { $ref: '#/components/schemas/BalanceEquationTermV2' }
+        ratio: { $ref: '#/components/schemas/ExchangeRateV2' }
+
+    RuleRequestCommonV2:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string, minLength: 1 }
+        severity: { $ref: '#/components/schemas/SeverityV2' }
+        cadence: { $ref: '#/components/schemas/CadenceV2' }
+        schedule: { $ref: '#/components/schemas/ScheduleV2' }
+        notifications:
+          type: array
+          items: { type: string }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+        enabled: { type: boolean }
+    BalanceEquationRuleRequestV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleRequestCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [balance_equation] }
+            templateSpec: { $ref: '#/components/schemas/BalanceEquationSpecV2' }
+    ExchangeRateBoundsRuleRequestV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleRequestCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [exchange_rate_bounds] }
+            templateSpec: { $ref: '#/components/schemas/ExchangeRateBoundsSpecV2' }
+    SourceConsensusRuleRequestV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleRequestCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [source_consensus] }
+            templateSpec: { $ref: '#/components/schemas/SourceConsensusSpecV2' }
+    CoverageRatioBoundsRuleRequestV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleRequestCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [coverage_ratio_bounds] }
+            templateSpec: { $ref: '#/components/schemas/CoverageRatioBoundsSpecV2' }
+    RuleRequestV2:
+      oneOf:
+        - $ref: '#/components/schemas/BalanceEquationRuleRequestV2'
+        - $ref: '#/components/schemas/ExchangeRateBoundsRuleRequestV2'
+        - $ref: '#/components/schemas/SourceConsensusRuleRequestV2'
+        - $ref: '#/components/schemas/CoverageRatioBoundsRuleRequestV2'
+      discriminator:
+        propertyName: templateKind
+        mapping:
+          balance_equation: '#/components/schemas/BalanceEquationRuleRequestV2'
+          exchange_rate_bounds: '#/components/schemas/ExchangeRateBoundsRuleRequestV2'
+          source_consensus: '#/components/schemas/SourceConsensusRuleRequestV2'
+          coverage_ratio_bounds: '#/components/schemas/CoverageRatioBoundsRuleRequestV2'
+    RulePatchRequestV2:
+      type: object
+      description: Partial update. A changed definition is validated as a complete V2 definition; contractVersion is immutable and cannot be supplied.
+      properties:
+        name: { type: string, minLength: 1 }
+        templateKind: { $ref: '#/components/schemas/TemplateKindV2' }
+        templateSpec:
+          oneOf:
+            - $ref: '#/components/schemas/BalanceEquationSpecV2'
+            - $ref: '#/components/schemas/ExchangeRateBoundsSpecV2'
+            - $ref: '#/components/schemas/SourceConsensusSpecV2'
+            - $ref: '#/components/schemas/CoverageRatioBoundsSpecV2'
+        enabled: { type: boolean }
+        severity: { $ref: '#/components/schemas/SeverityV2' }
+        schedule: { $ref: '#/components/schemas/ScheduleV2' }
+        notifications:
+          type: array
+          items: { type: string }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+
+    RuleCommonV2:
+      type: object
+      required: [id, contractVersion, name, enabled, severity, cadence, createdAt, updatedAt]
+      properties:
+        id: { type: string, format: uuid }
+        revision: { type: string, description: Content-derived identifier of the effective rule configuration. }
+        contractVersion: { $ref: '#/components/schemas/ContractVersionV2' }
+        name: { type: string }
+        compiledCEL: { type: string, readOnly: true }
+        enabled: { type: boolean }
+        severity: { $ref: '#/components/schemas/SeverityV2' }
+        cadence: { $ref: '#/components/schemas/CadenceV2' }
+        schedule: { $ref: '#/components/schemas/ScheduleV2' }
+        notifications:
+          type: array
+          items: { type: string }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+    BalanceEquationRuleV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [balance_equation] }
+            templateSpec: { $ref: '#/components/schemas/BalanceEquationSpecV2' }
+    ExchangeRateBoundsRuleV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [exchange_rate_bounds] }
+            templateSpec: { $ref: '#/components/schemas/ExchangeRateBoundsSpecV2' }
+    SourceConsensusRuleV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [source_consensus] }
+            templateSpec: { $ref: '#/components/schemas/SourceConsensusSpecV2' }
+    CoverageRatioBoundsRuleV2:
+      allOf:
+        - $ref: '#/components/schemas/RuleCommonV2'
+        - type: object
+          required: [templateKind, templateSpec]
+          properties:
+            templateKind: { type: string, enum: [coverage_ratio_bounds] }
+            templateSpec: { $ref: '#/components/schemas/CoverageRatioBoundsSpecV2' }
+    RuleV2:
+      oneOf:
+        - $ref: '#/components/schemas/BalanceEquationRuleV2'
+        - $ref: '#/components/schemas/ExchangeRateBoundsRuleV2'
+        - $ref: '#/components/schemas/SourceConsensusRuleV2'
+        - $ref: '#/components/schemas/CoverageRatioBoundsRuleV2'
+      discriminator:
+        propertyName: templateKind
+        mapping:
+          balance_equation: '#/components/schemas/BalanceEquationRuleV2'
+          exchange_rate_bounds: '#/components/schemas/ExchangeRateBoundsRuleV2'
+          source_consensus: '#/components/schemas/SourceConsensusRuleV2'
+          coverage_ratio_bounds: '#/components/schemas/CoverageRatioBoundsRuleV2'
+    RuleResponseV2:
+      type: object
+      required: [data]
+      properties:
+        data: { $ref: '#/components/schemas/RuleV2' }
+    RulesCursorResponseV2:
+      type: object
+      required: [cursor]
+      properties:
+        cursor:
+          type: object
+          required: [pageSize, hasMore, data]
+          properties:
+            pageSize: { type: integer, format: int64, minimum: 1, maximum: 1000 }
+            hasMore: { type: boolean }
+            previous: { type: string }
+            next: { type: string }
+            data:
+              type: array
+              items: { $ref: '#/components/schemas/RuleV2' }
+
+    EvidenceSourceV2:
+      type: object
+      required: [id, kind, asset, balance, present]
+      properties:
+        id: { $ref: '#/components/schemas/SourceIDV2' }
+        label: { type: string }
+        kind: { type: string, enum: [ledger, account_metadata] }
+        asset: { $ref: '#/components/schemas/AssetV2' }
+        balance: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+        present: { type: boolean }
+    BalanceEquationEvidenceSourceV2:
+      allOf:
+        - $ref: '#/components/schemas/EvidenceSourceV2'
+        - type: object
+          required: [coefficient, contribution]
+          properties:
+            coefficient:
+              oneOf:
+                - { type: integer, format: int64, maximum: -1 }
+                - { type: integer, format: int64, minimum: 1 }
+            contribution: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+    BalanceEquationEvidenceV2:
+      type: object
+      required: [schemaVersion, operation, asset, sources, residual, absoluteResidual, tolerance, compiledCEL]
+      properties:
+        schemaVersion: { type: integer, format: int32, enum: [2] }
+        operation: { type: string, enum: [balance_equation] }
+        asset: { $ref: '#/components/schemas/AssetV2' }
+        sources:
+          type: array
+          minItems: 2
+          maxItems: 32
+          items: { $ref: '#/components/schemas/BalanceEquationEvidenceSourceV2' }
+        residual: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+        absoluteResidual: { $ref: '#/components/schemas/UnsignedIntegerStringV2' }
+        tolerance: { $ref: '#/components/schemas/UnsignedIntegerStringV2' }
+        compiledCEL: { type: string }
+    RationalRateV2:
+      type: object
+      required: [numerator, denominator]
+      properties:
+        numerator: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+        denominator: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+    EffectiveRateBoundsV2:
+      type: object
+      required: [min, max]
+      properties:
+        min: { $ref: '#/components/schemas/PositiveDecimalStringV2' }
+        max: { $ref: '#/components/schemas/PositiveDecimalStringV2' }
+    ExchangeRateBoundsEvidenceV2:
+      type: object
+      description: "`observedRate` is omitted and `undefinedReason` is set only when the base balance is zero."
+      required: [schemaVersion, operation, base, quote, effectiveBounds, compiledCEL]
+      properties:
+        schemaVersion: { type: integer, format: int32, enum: [2] }
+        operation: { type: string, enum: [exchange_rate_bounds] }
+        base: { $ref: '#/components/schemas/EvidenceSourceV2' }
+        quote: { $ref: '#/components/schemas/EvidenceSourceV2' }
+        observedRate: { $ref: '#/components/schemas/RationalRateV2' }
+        effectiveBounds: { $ref: '#/components/schemas/EffectiveRateBoundsV2' }
+        undefinedReason: { type: string, enum: [base_balance_zero] }
+        compiledCEL: { type: string }
+    SourceConsensusEvidenceV2:
+      type: object
+      required: [schemaVersion, operation, asset, sources, minimumSource, minimumBalance, maximumSource, maximumBalance, spread, tolerance, missingSources, compiledCEL]
+      properties:
+        schemaVersion: { type: integer, format: int32, enum: [2] }
+        operation: { type: string, enum: [source_consensus] }
+        asset: { $ref: '#/components/schemas/AssetV2' }
+        sources:
+          type: array
+          minItems: 2
+          maxItems: 32
+          items: { $ref: '#/components/schemas/EvidenceSourceV2' }
+        minimumSource: { $ref: '#/components/schemas/SourceIDV2' }
+        minimumBalance: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+        maximumSource: { $ref: '#/components/schemas/SourceIDV2' }
+        maximumBalance: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+        spread: { $ref: '#/components/schemas/UnsignedIntegerStringV2' }
+        tolerance: { $ref: '#/components/schemas/UnsignedIntegerStringV2' }
+        missingSources:
+          type: array
+          items: { $ref: '#/components/schemas/SourceIDV2' }
+        compiledCEL: { type: string }
+    CoveragePortfolioV2:
+      type: object
+      required: [sources, total]
+      properties:
+        sources:
+          type: array
+          minItems: 1
+          maxItems: 31
+          items: { $ref: '#/components/schemas/BalanceEquationEvidenceSourceV2' }
+        total: { $ref: '#/components/schemas/SignedIntegerStringV2' }
+    CoverageRatioBoundsEvidenceV2:
+      type: object
+      description: "`observedRatio` is omitted and `undefinedReason` is set only when the denominator portfolio totals zero."
+      required: [schemaVersion, operation, asset, numerator, denominator, effectiveBounds, compiledCEL]
+      properties:
+        schemaVersion: { type: integer, format: int32, enum: [2] }
+        operation: { type: string, enum: [coverage_ratio_bounds] }
+        asset: { $ref: '#/components/schemas/AssetV2' }
+        numerator: { $ref: '#/components/schemas/CoveragePortfolioV2' }
+        denominator: { $ref: '#/components/schemas/CoveragePortfolioV2' }
+        observedRatio: { $ref: '#/components/schemas/RationalRateV2' }
+        effectiveBounds: { $ref: '#/components/schemas/EffectiveRateBoundsV2' }
+        undefinedReason: { type: string, enum: [denominator_total_zero] }
+        compiledCEL: { type: string }
+    EvidenceV2:
+      oneOf:
+        - $ref: '#/components/schemas/BalanceEquationEvidenceV2'
+        - $ref: '#/components/schemas/ExchangeRateBoundsEvidenceV2'
+        - $ref: '#/components/schemas/SourceConsensusEvidenceV2'
+        - $ref: '#/components/schemas/CoverageRatioBoundsEvidenceV2'
+      discriminator:
+        propertyName: operation
+        mapping:
+          balance_equation: '#/components/schemas/BalanceEquationEvidenceV2'
+          exchange_rate_bounds: '#/components/schemas/ExchangeRateBoundsEvidenceV2'
+          source_consensus: '#/components/schemas/SourceConsensusEvidenceV2'
+          coverage_ratio_bounds: '#/components/schemas/CoverageRatioBoundsEvidenceV2'
+
+    OutcomeV2:
+      type: object
+      required: [fingerprint, passed, evidence]
+      properties:
+        fingerprint: { type: string }
+        passed: { type: boolean }
+        evidence: { $ref: '#/components/schemas/EvidenceV2' }
+
+    EvaluateRuleRequestV2:
+      type: object
+      properties:
+        at: { type: string, format: date-time, description: "Point in time for the evaluation. Defaults to now." }
+    EvaluationV2:
+      type: object
+      required: [id, contractVersion, ruleID, startedAt, endedAt, result, createdAt]
+      properties:
+        id: { type: string, format: uuid }
+        contractVersion: { $ref: '#/components/schemas/ContractVersionV2' }
+        ruleID: { type: string, format: uuid }
+        startedAt: { type: string, format: date-time }
+        endedAt: { type: string, format: date-time }
+        result: { type: string, enum: [PASS, FAIL, ERROR] }
+        evidence:
+          oneOf:
+            - type: array
+              items: { $ref: '#/components/schemas/OutcomeV2' }
+            - type: object
+              additionalProperties: true
+        error: { type: string }
+        costUnits: { type: integer, format: int64 }
+        createdAt: { type: string, format: date-time }
+    EvaluationResponseV2:
+      type: object
+      required: [data]
+      properties:
+        data: { $ref: '#/components/schemas/EvaluationV2' }
+
+    AckV2:
+      type: object
+      required: [by, at]
+      properties:
+        by: { type: string }
+        at: { type: string, format: date-time }
+        note: { type: string }
+    ResolutionV2:
+      type: object
+      required: [kind, by, at]
+      properties:
+        kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+        by: { type: string }
+        at: { type: string, format: date-time }
+        note: { type: string }
+        transactionRefs:
+          type: array
+          items: { type: string }
+        evidenceSnapshot: { $ref: '#/components/schemas/EvidenceV2' }
+        expiresAt: { type: string, format: date-time }
+    SnoozeV2:
+      type: object
+      required: [until, by, at]
+      properties:
+        until: { type: string, format: date-time }
+        by: { type: string }
+        at: { type: string, format: date-time }
+        note: { type: string }
+    AlertV2:
+      type: object
+      required: [id, contractVersion, ruleID, fingerprint, periodID, status, severity, firstSeenAt, lastSeenAt, occurrenceCount, lastEvaluationID, createdAt, updatedAt]
+      properties:
+        id: { type: string, format: uuid }
+        contractVersion: { $ref: '#/components/schemas/ContractVersionV2' }
+        ruleID: { type: string, format: uuid }
+        fingerprint: { type: string }
+        periodID: { type: string }
+        status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+        severity: { $ref: '#/components/schemas/SeverityV2' }
+        firstSeenAt: { type: string, format: date-time }
+        lastSeenAt: { type: string, format: date-time }
+        occurrenceCount: { type: integer, format: int64 }
+        lastEvaluationID: { type: string, format: uuid }
+        evidence: { $ref: '#/components/schemas/EvidenceV2' }
+        ack: { $ref: '#/components/schemas/AckV2' }
+        resolution: { $ref: '#/components/schemas/ResolutionV2' }
+        snooze: { $ref: '#/components/schemas/SnoozeV2' }
+        labels:
+          type: object
+          additionalProperties: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+    AlertResponseV2:
+      type: object
+      required: [data]
+      properties:
+        data: { $ref: '#/components/schemas/AlertV2' }
+    AlertsCursorResponseV2:
+      type: object
+      required: [cursor]
+      properties:
+        cursor:
+          type: object
+          required: [pageSize, hasMore, data]
+          properties:
+            pageSize: { type: integer, format: int64 }
+            hasMore: { type: boolean }
+            previous: { type: string }
+            next: { type: string }
+            data:
+              type: array
+              items: { $ref: '#/components/schemas/AlertV2' }
+    CaptureV2:
+      type: object
+      required: [transactionID, contractVersion, ruleID, periodID, evaluationID, templateKind, verdict, trigger, capturedAt]
+      properties:
+        transactionID: { type: integer, format: int64 }
+        contractVersion: { $ref: '#/components/schemas/ContractVersionV2' }
+        ruleID: { type: string, format: uuid }
+        periodID: { type: string }
+        evaluationID: { type: string, format: uuid }
+        templateKind: { $ref: '#/components/schemas/TemplateKindV2' }
+        verdict: { type: string, enum: [pass, fail, error] }
+        trigger: { type: string, enum: [scheduled, manual] }
+        capturedAt: { type: string, format: date-time }
+        ruleRevision: { type: string }
+        pit: { type: string, format: date-time }
+        startedAt: { type: string, format: date-time }
+        result: { type: string, enum: [PASS, FAIL, ERROR] }
+        error: { type: string }
+        evidence:
+          oneOf:
+            - type: array
+              items: { $ref: '#/components/schemas/OutcomeV2' }
+            - type: object
+              additionalProperties: true
+    CapturesCursorResponseV2:
+      type: object
+      required: [cursor]
+      properties:
+        cursor:
+          type: object
+          required: [pageSize, hasMore, data]
+          properties:
+            pageSize: { type: integer, format: int64 }
+            hasMore: { type: boolean }
+            previous: { type: string }
+            next: { type: string }
+            data:
+              type: array
+              items: { $ref: '#/components/schemas/CaptureV2' }
+
+    AckAlertRequestV2:
+      type: object
+      required: [by]
+      properties:
+        by: { type: string, example: "ops@buildr.com" }
+        note: { type: string }
+    ResolveAlertRequestV2:
+      type: object
+      required: [by]
+      properties:
+        by: { type: string }
+        note: { type: string }
+        transactionRefs:
+          type: array
+          items: { type: string }
+    AcceptAlertRequestV2:
+      type: object
+      required: [by, note]
+      properties:
+        by: { type: string }
+        note: { type: string, minLength: 1 }
+        expiresAt: { type: string, format: date-time }
+    SnoozeAlertRequestV2:
+      type: object
+      required: [by, until]
+      properties:
+        by: { type: string, example: "ops@buildr.com" }
+        until: { type: string, format: date-time }
+        note: { type: string }
+    UnsnoozeAlertRequestV2:
       type: object
       required: [by]
       properties:


### PR DESCRIPTION
## Summary

- add an isolated V2 API with named multi-source balance equations, exchange-rate bounds, source consensus, and coverage-ratio bounds
- preserve the V1 `source_parity.left` / `.right` wire and evidence contracts while presenting validation errors as Source A / Source B
- persist contract versions and exact, complete evaluation evidence without cross-version resource leakage
- add a rule-scoped Ledger v3 activity journal combining rule revisions, evaluations, alert transitions, and manual alert interactions
- expose backed V1/V2 rule timeline endpoints; do not duplicate the deferred empty per-alert events endpoint in V2
- document the exact Ledger v3 chart, assets, Numscript v2 library, indexes, queries, provisioning, and compatibility model

## Compatibility

- missing persisted `contract_version` continues to decode as V1
- V1 response bodies do not expose V2 contract or revision fields
- V1 left/right template and evidence keys are unchanged
- activity history is forward-only; pre-rollout events are not fabricated
- the Ledger v3 base branch separately contains the release/v3.0 protobuf/color compatibility commit

## Audit semantics

Every evaluation capture retains all passing, failing, and error evidence, including the exact named-source values used for the verdict. Current-state metadata and its individual activity item commit atomically in one Ledger transaction. An evaluation capture and its derived transitions across multiple alerts remain separate idempotent Ledger transactions; a mid-sequence failure can therefore expose partial rule-level application and needs a future recovery/saga design.

## Documentation

- add `docs/technical/ledger-v3-storage.md` as the consolidated executable storage map
- add ADR-004 for the V2 contract and exact arithmetic semantics
- correct stale account-type, asset, Numscript-version, snooze, durability, and event-delivery descriptions

## Verification

- `just pre-commit`
- `go test ./...`
- `go test -race -covermode atomic -tags it -p 1 ./...`
- live Ledger v3 smoke: create V2 rule, evaluate PASS with retained evidence, read timeline, delete rule, read preserved timeline

All checks passed locally.