### PR TITLE
fix(reconciliation): honor publisher circuit breaker setting

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/fx/messagingfx"
 	"github.com/formancehq/go-libs/v5/pkg/messaging/publish"
 	v5logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	v5connect "github.com/formancehq/go-libs/v5/pkg/storage/bun/connect"
 	"github.com/formancehq/reconciliation/internal/api"
 	"github.com/formancehq/reconciliation/internal/storage"
 	"github.com/spf13/cobra"
@@ -79,13 +80,9 @@ func newServeCommand(version string) *cobra.Command {
 	iam.AddFlags(cmd.Flags())
 	service.AddFlags(cmd.Flags())
 	licence.AddFlags(cmd.Flags())
-	publish.AddFlags(ServiceName, cmd.Flags(), reconciliationPublisherDefaults)
+	publish.AddFlags(ServiceName, cmd.Flags())
 
 	return cmd
-}
-
-func reconciliationPublisherDefaults(config *publish.ConfigDefault) {
-	config.PublisherCircuitBreakerEnabled = true
 }
 
 func runServer(version string) func(cmd *cobra.Command, args []string) error {
@@ -141,10 +138,15 @@ func messagingLoggingModule(cmd *cobra.Command) fx.Option {
 }
 
 func prepareDatabaseOptions(cmd *cobra.Command) (fx.Option, error) {
-	connectionOptions, err := bunconnect.ConnectionOptionsFromFlags(cmd)
+	legacyConnectionOptions, err := bunconnect.ConnectionOptionsFromFlags(cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	return storage.Module(*connectionOptions, service.IsDebug(cmd)), nil
+	publisherConnectionOptions, err := v5connect.ConnectionOptionsFromFlags(cmd.Flags(), cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	return storage.Module(*legacyConnectionOptions, *publisherConnectionOptions, service.IsDebug(cmd)), nil
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -40,9 +40,14 @@ func TestWorkerOptionsAreValid(t *testing.T) {
 	require.NoError(t, fx.ValidateApp(options...))
 }
 
-func TestPublisherCircuitBreakerDefaultsEnabledOnAPIAndWorker(t *testing.T) {
+func TestPublisherCircuitBreakerIsOptInOnAPIAndWorker(t *testing.T) {
 	for _, command := range []*cobra.Command{newServeCommand("test"), newWorkerCommand("test")} {
 		enabled, err := command.Flags().GetBool(publish.PublisherCircuitBreakerEnabledFlag)
+		require.NoError(t, err)
+		require.False(t, enabled)
+
+		require.NoError(t, command.Flags().Set(publish.PublisherCircuitBreakerEnabledFlag, "true"))
+		enabled, err = command.Flags().GetBool(publish.PublisherCircuitBreakerEnabledFlag)
 		require.NoError(t, err)
 		require.True(t, enabled)
 	}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -54,7 +54,7 @@ func newWorkerCommand(version string) *cobra.Command {
 	bunconnect.AddFlags(cmd.Flags())
 	iam.AddFlags(cmd.Flags())
 	service.AddFlags(cmd.Flags())
-	publish.AddFlags(ServiceName, cmd.Flags(), reconciliationPublisherDefaults)
+	publish.AddFlags(ServiceName, cmd.Flags())
 	return cmd
 }
 

--- a/internal/storage/module.go
+++ b/internal/storage/module.go
@@ -21,23 +21,16 @@ type storageParams struct {
 	Publisher AlertEventPublisher `optional:"true"`
 }
 
-func Module(connectionOptions legacyconnect.ConnectionOptions, debug bool) fx.Option {
+func Module(connectionOptions legacyconnect.ConnectionOptions, publisherConnectionOptions v5connect.ConnectionOptions, debug bool) fx.Option {
 	return fx.Options(
 		fx.Provide(func() *legacyconnect.ConnectionOptions {
 			return &connectionOptions
 		}),
-		// go-libs v5's PostgreSQL circuit breaker owns a separate connection
-		// pool and consumes the v5 connection-options type. Keep the service's
-		// legacy Bun module for now, but expose the same DSN and pool bounds to
-		// the publisher so the breaker is actually wired on API and worker.
+		// go-libs v5's PostgreSQL circuit breaker owns a separate pgx-backed
+		// connection pool. Do not reuse the legacy lib/pq connector: the v5
+		// migrator unwraps pgx's stdlib.Conn for its progress listener.
 		fx.Provide(func() *v5connect.ConnectionOptions {
-			return &v5connect.ConnectionOptions{
-				DatabaseSourceName: connectionOptions.DatabaseSourceName,
-				MaxIdleConns:       connectionOptions.MaxIdleConns,
-				MaxOpenConns:       connectionOptions.MaxOpenConns,
-				ConnMaxIdleTime:    connectionOptions.ConnMaxIdleTime,
-				Connector:          connectionOptions.Connector,
-			}
+			return &publisherConnectionOptions
 		}),
 		legacyconnect.Module(connectionOptions, debug),
 		fx.Provide(func(p storageParams) *Storage {


### PR DESCRIPTION
## Summary

- keep the publisher circuit breaker opt-in on both API and worker
- build the optional publisher pool with the native v5 pgx connector instead of reusing the legacy lib/pq connector
- prevent the migration progress listener from panicking on startup

## Validation

- `just pre-commit`
- `just tests`