### PR TITLE
fix(events): follow ACTION_ENTITY naming

### DIFF
--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -76,7 +76,7 @@ The engine internals (rules, expressions, kernel) exist to serve this lifecycle,
 - Four template types: `ledger_vs_pool_drift` (port of today), `ledger_invariant`, `account_threshold`, `source_parity` (post-spec addition).
 - Cron + on-demand evaluation.
 - **Alert lifecycle including resolution** — auto-resolve on passing evaluation, manual *fixed by booking* (optional transaction refs), manual *accepted by business* (required note + author + evidence snapshot). Full append-only event log per alert (one row per evaluation + one per manual transition) — the audit substrate for `/alerts/{id}/events`.
-- Event publication: `reconciliation.alert.opened | updated | acknowledged | resolved | accepted | reopened | snoozed | unsnoozed`.
+- Event publication: `reconciliation.opened_alert | updated_alert | acknowledged_alert | resolved_alert | accepted_alert | reopened_alert | snoozed_alert | unsnoozed_alert`.
 - Webhook delivery via the existing Webhooks module + an email digest owned in-module.
 - Backwards compatibility: existing `Policy` evaluates as `ledger_vs_pool_drift`.
 - EE gating + usage metering.

--- a/docs/technical/alert-period-model.md
+++ b/docs/technical/alert-period-model.md
@@ -137,7 +137,7 @@ for existing rules and rows. Periodic scoping is **opt-in per rule**.
 
 ## Interaction with webhooks
 
-`period_id` rides on the `Alert` in every [`reconciliation.alert.*` event](api.md)
+`period_id` rides on the `Alert` in every [`reconciliation.*_alert` event](api.md)
 payload, so consumers can route/aggregate by period. `reopened` now means a
 *within-period* reopen; the same fingerprint failing in a new period is a fresh
 `opened`.

--- a/docs/technical/api.md
+++ b/docs/technical/api.md
@@ -305,14 +305,14 @@ This keeps a scheduled, still-broken rule from re-paging on every tick.
 
 | Event | Fires when | `alert_event` row |
 |---|---|---|
-| `reconciliation.alert.opened`       | First failing eval for a fingerprint | `fail`, `prevStatus = null` |
-| `reconciliation.alert.updated`      | Failure while OPEN/ACKNOWLEDGED **with new evidence** (identical repeats are suppressed) | `fail`, `prevStatus ∈ {OPEN, ACKNOWLEDGED}`, `notify = true` |
-| `reconciliation.alert.acknowledged` | Human ack'd | `ack` |
-| `reconciliation.alert.resolved`     | Auto-resolve (`pass`) or `fixed_by_booking` (`resolve`) | `pass` / `resolve` |
-| `reconciliation.alert.accepted`     | Business acceptance | `accept` |
-| `reconciliation.alert.reopened`     | Same fingerprint fails after a closed alert (status → OPEN, same alert id) | `fail`, `prevStatus = RESOLVED` |
-| `reconciliation.alert.snoozed`      | Operator muted the alert until a future instant | `snooze` |
-| `reconciliation.alert.unsnoozed`    | Snooze lifted early | `unsnooze` |
+| `reconciliation.opened_alert`       | First failing eval for a fingerprint | `fail`, `prevStatus = null` |
+| `reconciliation.updated_alert`      | Failure while OPEN/ACKNOWLEDGED **with new evidence** (identical repeats are suppressed) | `fail`, `prevStatus ∈ {OPEN, ACKNOWLEDGED}`, `notify = true` |
+| `reconciliation.acknowledged_alert` | Human ack'd | `ack` |
+| `reconciliation.resolved_alert`     | Auto-resolve (`pass`) or `fixed_by_booking` (`resolve`) | `pass` / `resolve` |
+| `reconciliation.accepted_alert`     | Business acceptance | `accept` |
+| `reconciliation.reopened_alert`     | Same fingerprint fails after a closed alert (status → OPEN, same alert id) | `fail`, `prevStatus = RESOLVED` |
+| `reconciliation.snoozed_alert`      | Operator muted the alert until a future instant | `snooze` |
+| `reconciliation.unsnoozed_alert`    | Snooze lifted early | `unsnooze` |
 
 The event name is a pure function of the row (`events.EventTypeFor`) — there is
 no separate event-kind column to keep in sync. An idempotent no-op (e.g. re-ack
@@ -323,13 +323,13 @@ snooze is in force, writes a row with `notify = false` and is **not** published
 — see [notification-suppression.md](./notification-suppression.md).
 
 **Envelope.** Standard `publish.EventMessage`: `app = "reconciliation"`,
-`version = "v1"`, `type ∈ {alert.opened, alert.updated, alert.acknowledged,
-alert.resolved, alert.accepted, alert.reopened, alert.snoozed,
-alert.unsnoozed}`, `idempotencyKey =` the `alert_event` id. The Webhooks worker
-lowercases and joins `app` + `type`, so subscribers match against the full names
-in the table above. All events publish to a single logical topic
-(`reconciliation`); the operator's `--publisher-topic-mapping` routes it to the
-bus subject Webhooks subscribes to.
+`version = "v1"`, `type ∈ {OPENED_ALERT, UPDATED_ALERT, ACKNOWLEDGED_ALERT,
+RESOLVED_ALERT, ACCEPTED_ALERT, REOPENED_ALERT, SNOOZED_ALERT,
+UNSNOOZED_ALERT}`, `idempotencyKey =` the `alert_event` id. The Webhooks worker
+lowercases `app` and `type`, then joins them with `.`, so subscribers match
+against the full names in the table above. All events publish to a single
+logical topic (`reconciliation`); the operator's `--publisher-topic-mapping`
+routes it to the bus subject Webhooks subscribes to.
 
 **Payload.** The full current `Alert` row (which carries the latest evaluation's
 `evidence`, plus `resolution` / `ack` / `labels`) paired with the triggering

--- a/docs/technical/notification-suppression.md
+++ b/docs/technical/notification-suppression.md
@@ -7,13 +7,13 @@
 
 Before the durable [scheduler worker](./scheduler.md) landed, evaluation was
 on-demand: an alert re-failed only when a human (or a script) re-ran the rule,
-so the `reconciliation.alert.updated` event was rare and meaningful.
+so the `reconciliation.updated_alert` event was rare and meaningful.
 
 Once rules evaluate on a cadence, that stops being true. Every failing
 evaluation appends a `fail` row and publishes a webhook
 ([api.md §Events](./api.md#events)), and the row→event mapping is
 `fail + prev ∈ {OPEN, ACKNOWLEDGED} → updated`. So a rule on a 5-minute cron
-that stays broken emits `reconciliation.alert.updated` **every 5 minutes,
+that stays broken emits `reconciliation.updated_alert` **every 5 minutes,
 indefinitely** — each one fanning out through Webhooks to the customer's Slack /
 PagerDuty / email. A discrepancy that hovers at the tolerance boundary makes it
 worse. None of those repeats carry information the consumer doesn't already

--- a/docs/technical/workflows.md
+++ b/docs/technical/workflows.md
@@ -198,8 +198,8 @@ flowchart LR
   if the alert isn't snoozed).
 - `snooze` and `unsnooze` are status-neutral `alert_event` rows
   (`prev_status == new_status`) and themselves notify
-  (`reconciliation.alert.snoozed` / `.unsnoozed`), so downstream consumers can
-  reflect the mute state.
+  (`reconciliation.snoozed_alert` / `.unsnoozed_alert`), so downstream
+  consumers can reflect the mute state.
 
 > **V1 scope.** Snooze is **per-alert**. Rule-level snooze (a maintenance window
 > that mutes a whole rule before it fires) and snooze-vs-digest interaction are

--- a/internal/events/alert.go
+++ b/internal/events/alert.go
@@ -17,8 +17,8 @@ import (
 const (
 	// EventApp is the `app` field of every published message. The Webhooks
 	// worker lowercases it and prepends it to the type, so a message with
-	// App="reconciliation" and Type="alert.opened" is matched by subscribers
-	// against the event name "reconciliation.alert.opened". Mirrors
+	// App="reconciliation" and Type="OPENED_ALERT" is matched by subscribers
+	// against the event name "reconciliation.opened_alert". Mirrors
 	// cmd.ServiceName (kept as a literal here to avoid importing cmd).
 	EventApp = "reconciliation"
 	// EventVersion tags the payload schema. Bumped only on a breaking change
@@ -27,26 +27,26 @@ const (
 	// Topic is the logical topic every alert event is published to. The
 	// operator's --publisher-topic-mapping routes it to the physical
 	// subject the Webhooks module subscribes to (a single `*:<subject>` or
-	// `reconciliation:<subject>` mapping covers all six event types — the
+	// `reconciliation:<subject>` mapping covers all eight event types — the
 	// `type` field discriminates them downstream).
 	Topic = "reconciliation"
 )
 
-// Event type suffixes. The consumer-facing event name is EventApp + "." +
-// <suffix> (assembled by the Webhooks worker), e.g. "reconciliation.alert.opened".
+// Event types follow the public Formance ACTION_ENTITY convention. Webhooks
+// lowercases and joins EventApp + "." + <type>, e.g. "reconciliation.opened_alert".
 // The full table lives in docs/technical/api.md §Events.
 const (
-	EventTypeAlertOpened       = "alert.opened"
-	EventTypeAlertUpdated      = "alert.updated"
-	EventTypeAlertAcknowledged = "alert.acknowledged"
-	EventTypeAlertResolved     = "alert.resolved"
-	EventTypeAlertAccepted     = "alert.accepted"
-	EventTypeAlertReopened     = "alert.reopened"
-	EventTypeAlertSnoozed      = "alert.snoozed"
-	EventTypeAlertUnsnoozed    = "alert.unsnoozed"
+	EventTypeAlertOpened       = "OPENED_ALERT"
+	EventTypeAlertUpdated      = "UPDATED_ALERT"
+	EventTypeAlertAcknowledged = "ACKNOWLEDGED_ALERT"
+	EventTypeAlertResolved     = "RESOLVED_ALERT"
+	EventTypeAlertAccepted     = "ACCEPTED_ALERT"
+	EventTypeAlertReopened     = "REOPENED_ALERT"
+	EventTypeAlertSnoozed      = "SNOOZED_ALERT"
+	EventTypeAlertUnsnoozed    = "UNSNOOZED_ALERT"
 )
 
-// AlertEventPayload is the wire shape carried by every reconciliation.alert.*
+// AlertEventPayload is the wire shape carried by every reconciliation.*_alert
 // event. It pairs the alert's current state (which embeds the latest
 // evaluation's evidence on Alert.Evidence) with the append-only event row that
 // triggered the publish — giving consumers the transition (prev→new status,

--- a/internal/events/alert_test.go
+++ b/internal/events/alert_test.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,6 +64,16 @@ func TestEventTypeFor(t *testing.T) {
 			want:  EventTypeAlertAccepted,
 		},
 		{
+			name:  "snooze → snoozed",
+			event: models.AlertEvent{Type: models.AlertEventSnooze, PrevStatus: statusPtr(models.AlertOpen), NewStatus: models.AlertOpen},
+			want:  EventTypeAlertSnoozed,
+		},
+		{
+			name:  "unsnooze → unsnoozed",
+			event: models.AlertEvent{Type: models.AlertEventUnsnooze, PrevStatus: statusPtr(models.AlertOpen), NewStatus: models.AlertOpen},
+			want:  EventTypeAlertUnsnoozed,
+		},
+		{
 			name:  "unknown type → empty (do not publish)",
 			event: models.AlertEvent{Type: models.AlertEventType("bogus")},
 			want:  "",
@@ -72,6 +83,33 @@ func TestEventTypeFor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, EventTypeFor(&tc.event))
 		})
+	}
+}
+
+func TestPublicEventTypeNames(t *testing.T) {
+	t.Parallel()
+	types := []struct {
+		eventType   string
+		wantType    string
+		wantWebhook string
+	}{
+		{EventTypeAlertOpened, "OPENED_ALERT", "reconciliation.opened_alert"},
+		{EventTypeAlertUpdated, "UPDATED_ALERT", "reconciliation.updated_alert"},
+		{EventTypeAlertAcknowledged, "ACKNOWLEDGED_ALERT", "reconciliation.acknowledged_alert"},
+		{EventTypeAlertResolved, "RESOLVED_ALERT", "reconciliation.resolved_alert"},
+		{EventTypeAlertAccepted, "ACCEPTED_ALERT", "reconciliation.accepted_alert"},
+		{EventTypeAlertReopened, "REOPENED_ALERT", "reconciliation.reopened_alert"},
+		{EventTypeAlertSnoozed, "SNOOZED_ALERT", "reconciliation.snoozed_alert"},
+		{EventTypeAlertUnsnoozed, "UNSNOOZED_ALERT", "reconciliation.unsnoozed_alert"},
+	}
+	require.Len(t, types, 8)
+
+	for _, tc := range types {
+		require.Equal(t, tc.wantType, tc.eventType)
+		// Webhooks normalizes the envelope by lowercasing app and type, then
+		// joining both with a dot.
+		got := strings.ToLower(EventApp) + "." + strings.ToLower(tc.eventType)
+		require.Equal(t, tc.wantWebhook, got)
 	}
 }
 
@@ -122,7 +160,7 @@ func TestPublisher_PublishAlertEvent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.msgs[0].Payload, &env))
 	require.Equal(t, EventApp, env.App)
 	require.Equal(t, EventVersion, env.Version)
-	require.Equal(t, EventTypeAlertResolved, env.Type)
+	require.Equal(t, "RESOLVED_ALERT", env.Type)
 	require.Equal(t, event.ID.String(), env.IdempotencyKey)
 	require.True(t, event.At.Equal(env.Date))
 

--- a/internal/storage/alert.go
+++ b/internal/storage/alert.go
@@ -359,7 +359,7 @@ func (s *Storage) AckAlert(ctx context.Context, id uuid.UUID, ack *models.Ack) (
 		return nil, err
 	}
 	// event is nil on the idempotent re-ack no-op — recordAlertEvent skips it,
-	// so a duplicate ack does not re-emit reconciliation.alert.acknowledged.
+	// so a duplicate ack does not re-emit reconciliation.acknowledged_alert.
 	s.recordAlertEvent(ctx, &alert, event)
 	return &alert, nil
 }


### PR DESCRIPTION
## What changed

- rename Reconciliation alert event types to the Formance `ACTION_ENTITY` convention
- document the resulting Webhooks names such as `reconciliation.opened_alert`
- cover all eight lifecycle mappings and their normalized public names

## Why

Reconciliation published dotted entity/action suffixes such as `alert.opened`, while Formance public events use uppercase `ACTION_ENTITY` types. Webhooks lowercases the app and type and joins them with a dot, so publishing `OPENED_ALERT` produces the expected `reconciliation.opened_alert` subscription name.

## Impact

Webhook subscribers must use the new `reconciliation.*_alert` event names. The event payload schema and lifecycle behavior are unchanged.

## Validation

- `nix develop --impure --command just pc`
- `go test ./...`
- `go test -race ./internal/events ./internal/storage`
- exact repository search for the retired event names
